### PR TITLE
UI: rebrand to dnsmon and show country flags with hover tooltips

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = ".tmp"
 
 [build]
 cmd = "make build"
-bin = "./bin/gdns"
+bin = "./bin/dnsmon"
 include_ext = ["go", "html", "css", "js"]
 exclude_dir = ["web/node_modules", ".tmp", "bin"]
 delay = 500

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,9 +6,9 @@ before:
     - go mod tidy
 
 builds:
-  - id: gdns
-    main: ./cmd/gdns
-    binary: gdns
+  - id: dnsmon
+    main: ./cmd/dnsmon
+    binary: dnsmon
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,9 +20,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/tomerklein/gdns/internal/version.Version={{.Version}}
-      - -X github.com/tomerklein/gdns/internal/version.Commit={{.ShortCommit}}
-      - -X github.com/tomerklein/gdns/internal/version.Date={{.Date}}
+      - -X github.com/t0mer/dnsmon/internal/version.Version={{.Version}}
+      - -X github.com/t0mer/dnsmon/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/t0mer/dnsmon/internal/version.Date={{.Date}}
 
 archives:
   - format: tar.gz
@@ -33,8 +33,8 @@ archives:
 
 dockers:
   - image_templates:
-      - "ghcr.io/tomerklein/gdns:{{ .Tag }}"
-      - "ghcr.io/tomerklein/gdns:latest"
+      - "ghcr.io/t0mer/dnsmon:{{ .Tag }}"
+      - "ghcr.io/t0mer/dnsmon:latest"
     dockerfile: deploy/Dockerfile
     use: buildx
     build_flag_templates:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Self-Hosted DNS Propagation Checker
 
-> Project codename: **`gdns`** (Global DNS Checker)
+> Project codename: **`dnsmon`** (Global DNS Checker)
 > A self-hosted, open-source alternative to [whatsmydns.net](https://www.whatsmydns.net/), written in **Go**.
 
 This file is the single source of truth for Claude (and any other contributor / agent) working on this codebase. Read it in full before generating, modifying, or refactoring anything.
@@ -9,7 +9,7 @@ This file is the single source of truth for Claude (and any other contributor / 
 
 ## 1. Project Overview
 
-`gdns` is a web service that performs **DNS propagation checks** by querying a configurable list of public (and optionally private) DNS resolvers around the world and returning the answers each resolver gives for a requested record. It mirrors the feature set of `whatsmydns.net`:
+`dnsmon` is a web service that performs **DNS propagation checks** by querying a configurable list of public (and optionally private) DNS resolvers around the world and returning the answers each resolver gives for a requested record. It mirrors the feature set of `whatsmydns.net`:
 
 - Global DNS propagation checks across 100+ resolvers
 - Single-resolver authoritative DNS lookup ("DNS Lookup" tool)
@@ -33,7 +33,7 @@ The goal: **deploy with one `docker compose up` and have a private whatsmydns in
 | Language             | Go 1.23+                                           | Single static binary, great concurrency for fan-out DNS queries.        |
 | HTTP router          | `chi` (`github.com/go-chi/chi/v5`)                 | Idiomatic, fast, middleware-friendly, std-lib `http.Handler` compatible. |
 | DNS library          | `github.com/miekg/dns`                             | Industry standard, supports every record type we need.                  |
-| Config               | `github.com/spf13/viper` + env vars                | YAML config + `GDNS_*` env overrides.                                    |
+| Config               | `github.com/spf13/viper` + env vars                | YAML config + `DNSMON_*` env overrides.                                    |
 | Logging              | `log/slog` (stdlib, structured)                    | Use JSON handler in prod, text in dev.                                  |
 | Validation           | `github.com/go-playground/validator/v10`           | Validate API requests.                                                  |
 | Storage (optional)   | SQLite (`modernc.org/sqlite`) or Postgres (`pgx`)  | History, saved checks, rate-limit buckets. Pure-Go SQLite by default.   |
@@ -52,7 +52,7 @@ The goal: **deploy with one `docker compose up` and have a private whatsmydns in
 ## 3. Folder Structure
 
 ```
-gdns/
+dnsmon/
 ├── CLAUDE.md                       # ← this file
 ├── README.md                       # User-facing readme (install, run, screenshots)
 ├── LICENSE                         # MIT
@@ -67,7 +67,7 @@ gdns/
 │       └── release.yml             # goreleaser on tag
 │
 ├── cmd/
-│   └── gdns/
+│   └── dnsmon/
 │       └── main.go                 # Entrypoint: parses flags/config, wires DI, starts HTTP server.
 │
 ├── internal/                       # All non-public code lives here.
@@ -163,10 +163,10 @@ gdns/
 │
 ├── deploy/
 │   ├── Dockerfile                  # Multi-stage: node→tailwind, go→binary, distroless final.
-│   ├── docker-compose.yml          # gdns + (optional) postgres + redis.
+│   ├── docker-compose.yml          # dnsmon + (optional) postgres + redis.
 │   ├── docker-compose.sqlite.yml   # Minimal SQLite-only stack.
 │   ├── systemd/
-│   │   └── gdns.service
+│   │   └── dnsmon.service
 │   └── k8s/
 │       ├── deployment.yaml
 │       ├── service.yaml
@@ -480,12 +480,12 @@ Headers returned: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Res
 
 ## 9. Configuration
 
-`config.yaml` (overridable by env vars `GDNS_*`, e.g. `GDNS_SERVER_LISTEN`):
+`config.yaml` (overridable by env vars `DNSMON_*`, e.g. `DNSMON_SERVER_LISTEN`):
 
 ```yaml
 server:
   listen: ":8080"
-  base_url: "https://gdns.example.com"
+  base_url: "https://dnsmon.example.com"
   read_timeout: 10s
   write_timeout: 30s
 
@@ -502,7 +502,7 @@ resolvers:
 
 storage:
   driver: "sqlite"        # sqlite | postgres | none
-  dsn: "file:./gdns.db?cache=shared&_fk=1"
+  dsn: "file:./dnsmon.db?cache=shared&_fk=1"
   retention_days: 30      # auto-purge old saved checks
 
 cache:
@@ -576,10 +576,10 @@ metrics:
 
 ```bash
 # Local dev
-make dev               # runs go run ./cmd/gdns with hot-reload via air
+make dev               # runs go run ./cmd/dnsmon with hot-reload via air
 
 # Build single binary (embedded UI + resolvers)
-make build             # → ./bin/gdns
+make build             # → ./bin/dnsmon
 
 # Test
 make test              # go test ./...
@@ -593,7 +593,7 @@ make ui                # tailwind build → web/dist
 make ui-watch          # tailwind --watch
 
 # Docker
-make docker            # builds deploy/Dockerfile, tags gdns:latest
+make docker            # builds deploy/Dockerfile, tags dnsmon:latest
 
 # Release
 make release           # goreleaser release --clean
@@ -602,7 +602,7 @@ make release           # goreleaser release --clean
 Dockerfile uses three stages:
 1. `node:20-alpine` — builds Tailwind CSS into `web/dist/`.
 2. `golang:1.23-alpine` — `go build -trimpath -ldflags="-s -w -X .../version.Version=..."` with `CGO_ENABLED=0`.
-3. `gcr.io/distroless/static:nonroot` — copy binary; `ENTRYPOINT ["/gdns"]`.
+3. `gcr.io/distroless/static:nonroot` — copy binary; `ENTRYPOINT ["/dnsmon"]`.
 
 ---
 

--- a/cmd/dnsmon/main.go
+++ b/cmd/dnsmon/main.go
@@ -11,16 +11,16 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tomerklein/gdns/internal/api"
-	"github.com/tomerklein/gdns/internal/cache"
-	"github.com/tomerklein/gdns/internal/checker"
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/resolvers"
-	"github.com/tomerklein/gdns/internal/storage"
-	sqlitestore "github.com/tomerklein/gdns/internal/storage/sqlite"
-	pgstore "github.com/tomerklein/gdns/internal/storage/postgres"
-	"github.com/tomerklein/gdns/internal/version"
+	"github.com/t0mer/dnsmon/internal/api"
+	"github.com/t0mer/dnsmon/internal/cache"
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/storage"
+	sqlitestore "github.com/t0mer/dnsmon/internal/storage/sqlite"
+	pgstore "github.com/t0mer/dnsmon/internal/storage/postgres"
+	"github.com/t0mer/dnsmon/internal/version"
 )
 
 func main() {
@@ -54,7 +54,7 @@ func main() {
 	defer cancel()
 
 	info := version.BuildInfo()
-	log.Info("starting gdns",
+	log.Info("starting dnsmon",
 		slog.String("version", info.Version),
 		slog.String("commit", info.Commit),
 		slog.String("listen", cfg.Server.Listen),

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,26 +1,26 @@
 ##############################################################################
-# gdns — Global DNS Checker
+# dnsmon — Global DNS Checker
 # Example configuration file with all available options documented.
 # Copy this to config.yaml and adjust for your environment.
-# All options can be overridden with GDNS_* environment variables.
-# e.g. GDNS_SERVER_LISTEN=":9090" overrides server.listen.
+# All options can be overridden with DNSMON_* environment variables.
+# e.g. DNSMON_SERVER_LISTEN=":9090" overrides server.listen.
 ##############################################################################
 
 server:
   # Address and port to listen on.
-  # Env: GDNS_SERVER_LISTEN
+  # Env: DNSMON_SERVER_LISTEN
   listen: ":8080"
 
   # Public base URL used for permalink generation.
-  # Env: GDNS_SERVER_BASE_URL
-  base_url: "https://gdns.example.com"
+  # Env: DNSMON_SERVER_BASE_URL
+  base_url: "https://dnsmon.example.com"
 
   # Maximum time to read the full request, including body.
-  # Env: GDNS_SERVER_READ_TIMEOUT
+  # Env: DNSMON_SERVER_READ_TIMEOUT
   read_timeout: 10s
 
   # Maximum time to write the full response.
-  # Env: GDNS_SERVER_WRITE_TIMEOUT
+  # Env: DNSMON_SERVER_WRITE_TIMEOUT
   write_timeout: 120s
 
 ##############################################################################
@@ -28,20 +28,20 @@ server:
 ##############################################################################
 dns:
   # Timeout per individual DNS query to a single resolver.
-  # Env: GDNS_DNS_QUERY_TIMEOUT
+  # Env: DNSMON_DNS_QUERY_TIMEOUT
   query_timeout: 3s
 
   # How many concurrent outbound queries to allow per propagation check.
-  # Env: GDNS_DNS_PER_RESOLVER_CONCURRENCY
+  # Env: DNSMON_DNS_PER_RESOLVER_CONCURRENCY
   per_resolver_concurrency: 50
 
   # Default transport protocol for DNS queries.
   # Options: udp | tcp | dot (DNS-over-TLS) | doh (DNS-over-HTTPS)
-  # Env: GDNS_DNS_DEFAULT_PROTOCOL
+  # Env: DNSMON_DNS_DEFAULT_PROTOCOL
   default_protocol: "udp"
 
   # Number of retries for failed queries before marking as error.
-  # Env: GDNS_DNS_RETRY
+  # Env: DNSMON_DNS_RETRY
   retry: 1
 
 ##############################################################################
@@ -49,17 +49,17 @@ dns:
 ##############################################################################
 resolvers:
   # Whether to include the built-in curated resolver list (~100 resolvers).
-  # Env: GDNS_RESOLVERS_BUILTIN
+  # Env: DNSMON_RESOLVERS_BUILTIN
   builtin: true
 
   # Optional path to a YAML or JSON file with additional custom resolvers.
   # These are merged with (or replace, depending on IDs) the built-in list.
-  # Env: GDNS_RESOLVERS_FILE
+  # Env: DNSMON_RESOLVERS_FILE
   file: ""
 
   # Optional ISO-3166 alpha-2 country code whitelist. If non-empty, only
   # resolvers in the listed countries will be used.
-  # Env: GDNS_RESOLVERS_COUNTRIES (comma-separated)
+  # Env: DNSMON_RESOLVERS_COUNTRIES (comma-separated)
   countries: []
   # Example: countries: [US, DE, JP, AU]
 
@@ -69,17 +69,17 @@ resolvers:
 storage:
   # Storage driver. Options: sqlite | postgres | none
   # Use "none" to disable check history and permalink storage.
-  # Env: GDNS_STORAGE_DRIVER
+  # Env: DNSMON_STORAGE_DRIVER
   driver: "sqlite"
 
   # Data source name for the selected driver.
-  # SQLite example:  file:./gdns.db?cache=shared&_fk=1
-  # Postgres example: postgres://user:password@localhost:5432/gdns?sslmode=disable
-  # Env: GDNS_STORAGE_DSN
-  dsn: "file:./gdns.db?cache=shared&_fk=1"
+  # SQLite example:  file:./dnsmon.db?cache=shared&_fk=1
+  # Postgres example: postgres://user:password@localhost:5432/dnsmon?sslmode=disable
+  # Env: DNSMON_STORAGE_DSN
+  dsn: "file:./dnsmon.db?cache=shared&_fk=1"
 
   # Automatically delete saved checks older than this many days. 0 = never.
-  # Env: GDNS_STORAGE_RETENTION_DAYS
+  # Env: DNSMON_STORAGE_RETENTION_DAYS
   retention_days: 30
 
 ##############################################################################
@@ -87,19 +87,19 @@ storage:
 ##############################################################################
 cache:
   # Cache driver. Options: memory | redis | none
-  # Env: GDNS_CACHE_DRIVER
+  # Env: DNSMON_CACHE_DRIVER
   driver: "memory"
 
   # How long to cache a (name, type, resolver) response tuple.
-  # Env: GDNS_CACHE_TTL
+  # Env: DNSMON_CACHE_TTL
   ttl: 60s
 
   # Maximum number of entries in the in-memory LRU cache (memory driver only).
-  # Env: GDNS_CACHE_SIZE
+  # Env: DNSMON_CACHE_SIZE
   size: 10000
 
   # Redis connection address (redis driver only). Format: host:port
-  # Env: GDNS_CACHE_REDIS_ADDR
+  # Env: DNSMON_CACHE_REDIS_ADDR
   redis_addr: ""
   # Example: redis_addr: "localhost:6379"
 
@@ -108,15 +108,15 @@ cache:
 ##############################################################################
 ratelimit:
   # Whether rate limiting is enabled.
-  # Env: GDNS_RATELIMIT_ENABLED
+  # Env: DNSMON_RATELIMIT_ENABLED
   enabled: true
 
   # Maximum requests per minute for anonymous (unauthenticated) callers per IP.
-  # Env: GDNS_RATELIMIT_ANON_PER_MIN
+  # Env: DNSMON_RATELIMIT_ANON_PER_MIN
   anon_per_min: 30
 
   # Maximum requests per minute for authenticated callers (API key holders).
-  # Env: GDNS_RATELIMIT_KEY_PER_MIN
+  # Env: DNSMON_RATELIMIT_KEY_PER_MIN
   key_per_min: 600
 
 ##############################################################################
@@ -126,25 +126,25 @@ ratelimit:
 ##############################################################################
 geoip:
   # Whether to enable MaxMind GeoLite2 lookups.
-  # Env: GDNS_GEOIP_ENABLED
+  # Env: DNSMON_GEOIP_ENABLED
   enabled: false
 
   # Path to the MaxMind GeoLite2-City.mmdb database file.
-  # Env: GDNS_GEOIP_MMDB_PATH
+  # Env: DNSMON_GEOIP_MMDB_PATH
   mmdb_path: ""
-  # Example: mmdb_path: "/etc/gdns/GeoLite2-City.mmdb"
+  # Example: mmdb_path: "/etc/dnsmon/GeoLite2-City.mmdb"
 
 ##############################################################################
 # Logging
 ##############################################################################
 log:
   # Minimum log level. Options: debug | info | warn | error
-  # Env: GDNS_LOG_LEVEL
+  # Env: DNSMON_LOG_LEVEL
   level: "info"
 
   # Log output format. Options: json | text
   # Use "json" in production for structured log ingestion.
-  # Env: GDNS_LOG_FORMAT
+  # Env: DNSMON_LOG_FORMAT
   format: "json"
 
 ##############################################################################
@@ -152,9 +152,9 @@ log:
 ##############################################################################
 metrics:
   # Whether to expose the Prometheus metrics endpoint.
-  # Env: GDNS_METRICS_ENABLED
+  # Env: DNSMON_METRICS_ENABLED
   enabled: true
 
   # Path at which to serve the metrics endpoint.
-  # Env: GDNS_METRICS_PATH
+  # Env: DNSMON_METRICS_PATH
   path: "/metrics"

--- a/deploy/docker-compose.sqlite.yml
+++ b/deploy/docker-compose.sqlite.yml
@@ -1,20 +1,20 @@
 version: "3.9"
 services:
-  gdns:
-    image: ghcr.io/tomerklein/gdns:latest
+  dnsmon:
+    image: ghcr.io/t0mer/dnsmon:latest
     build:
       context: ..
       dockerfile: deploy/Dockerfile
     ports:
       - "8080:8080"
     environment:
-      GDNS_STORAGE_DRIVER: "sqlite"
-      GDNS_STORAGE_DSN: "file:/data/gdns.db?cache=shared&_fk=1"
-      GDNS_CACHE_DRIVER: "memory"
-      GDNS_LOG_FORMAT: "json"
+      DNSMON_STORAGE_DRIVER: "sqlite"
+      DNSMON_STORAGE_DSN: "file:/data/dnsmon.db?cache=shared&_fk=1"
+      DNSMON_CACHE_DRIVER: "memory"
+      DNSMON_LOG_FORMAT: "json"
     volumes:
-      - gdnsdata:/data
+      - dnsmondata:/data
     restart: unless-stopped
 
 volumes:
-  gdnsdata:
+  dnsmondata:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,19 +1,19 @@
 version: "3.9"
 services:
-  gdns:
-    image: ghcr.io/tomerklein/gdns:latest
+  dnsmon:
+    image: ghcr.io/t0mer/dnsmon:latest
     build:
       context: ..
       dockerfile: deploy/Dockerfile
     ports:
       - "8080:8080"
     environment:
-      GDNS_SERVER_LISTEN: ":8080"
-      GDNS_STORAGE_DRIVER: "postgres"
-      GDNS_STORAGE_DSN: "postgres://gdns:gdns@postgres:5432/gdns?sslmode=disable"
-      GDNS_CACHE_DRIVER: "redis"
-      GDNS_CACHE_REDIS_ADDR: "redis:6379"
-      GDNS_LOG_FORMAT: "json"
+      DNSMON_SERVER_LISTEN: ":8080"
+      DNSMON_STORAGE_DRIVER: "postgres"
+      DNSMON_STORAGE_DSN: "postgres://dnsmon:dnsmon@postgres:5432/dnsmon?sslmode=disable"
+      DNSMON_CACHE_DRIVER: "redis"
+      DNSMON_CACHE_REDIS_ADDR: "redis:6379"
+      DNSMON_LOG_FORMAT: "json"
     depends_on:
       postgres:
         condition: service_healthy
@@ -24,13 +24,13 @@ services:
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: gdns
-      POSTGRES_PASSWORD: gdns
-      POSTGRES_DB: gdns
+      POSTGRES_USER: dnsmon
+      POSTGRES_PASSWORD: dnsmon
+      POSTGRES_DB: dnsmon
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U gdns"]
+      test: ["CMD-SHELL", "pg_isready -U dnsmon"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gdns
+  name: dnsmon
   labels:
-    app: gdns
+    app: dnsmon
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: gdns
+      app: dnsmon
   template:
     metadata:
       labels:
-        app: gdns
+        app: dnsmon
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
@@ -23,23 +23,23 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
       containers:
-        - name: gdns
-          image: ghcr.io/tomerklein/gdns:latest
+        - name: dnsmon
+          image: ghcr.io/t0mer/dnsmon:latest
           imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
           env:
-            - name: GDNS_SERVER_LISTEN
+            - name: DNSMON_SERVER_LISTEN
               value: ":8080"
-            - name: GDNS_LOG_FORMAT
+            - name: DNSMON_LOG_FORMAT
               value: "json"
-            - name: GDNS_STORAGE_DRIVER
+            - name: DNSMON_STORAGE_DRIVER
               value: "sqlite"
-            - name: GDNS_STORAGE_DSN
-              value: "file:/data/gdns.db?cache=shared&_fk=1"
-            - name: GDNS_CACHE_DRIVER
+            - name: DNSMON_STORAGE_DSN
+              value: "file:/data/dnsmon.db?cache=shared&_fk=1"
+            - name: DNSMON_CACHE_DRIVER
               value: "memory"
           resources:
             requests:

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,9 +1,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: gdns
+  name: dnsmon
   labels:
-    app: gdns
+    app: dnsmon
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
@@ -19,16 +19,16 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - gdns.example.com
-      secretName: gdns-tls
+        - dnsmon.example.com
+      secretName: dnsmon-tls
   rules:
-    - host: gdns.example.com
+    - host: dnsmon.example.com
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: gdns
+                name: dnsmon
                 port:
                   name: http

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gdns
+  name: dnsmon
   labels:
-    app: gdns
+    app: dnsmon
 spec:
   type: ClusterIP
   selector:
-    app: gdns
+    app: dnsmon
   ports:
     - name: http
       port: 8080

--- a/deploy/systemd/gdns.service
+++ b/deploy/systemd/gdns.service
@@ -1,17 +1,17 @@
 [Unit]
-Description=gdns - Self-Hosted DNS Propagation Checker
+Description=dnsmon - Self-Hosted DNS Propagation Checker
 After=network.target
 
 [Service]
 Type=simple
-User=gdns
-Group=gdns
-ExecStart=/usr/local/bin/gdns --config /etc/gdns/config.yaml
+User=dnsmon
+Group=dnsmon
+ExecStart=/usr/local/bin/dnsmon --config /etc/dnsmon/config.yaml
 Restart=on-failure
 RestartSec=5s
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=gdns
+SyslogIdentifier=dnsmon
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
 PrivateTmp=true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# gdns Architecture
+# dnsmon Architecture
 
 ## Overview
 
-gdns is a self-hosted DNS propagation checker. A single Go binary embeds the frontend (HTML/CSS/JS), the curated resolver list, and serves all traffic. No separate web server, asset CDN, or runtime Node.js required.
+dnsmon is a self-hosted DNS propagation checker. A single Go binary embeds the frontend (HTML/CSS/JS), the curated resolver list, and serves all traffic. No separate web server, asset CDN, or runtime Node.js required.
 
 ---
 
@@ -76,7 +76,7 @@ checker.StreamCheck(ctx, params, resultsCh)
 ## Package Dependency Graph
 
 ```
-cmd/gdns
+cmd/dnsmon
     └── internal/api
             ├── internal/checker
             │       ├── internal/dnsclient
@@ -184,7 +184,7 @@ The frontend is vanilla HTML + Alpine.js + Leaflet.js + Tailwind CSS. No bundler
 
 - `web/src/*.html` — page templates
 - `web/src/css/tailwind.src.css` — Tailwind input, compiled at build time
-- `web/src/js/app.js` — Alpine.js components (`gdnsApp`, `lookupApp`, `reverseApp`)
+- `web/src/js/app.js` — Alpine.js components (`dnsmonApp`, `lookupApp`, `reverseApp`)
 - `web/src/js/map.js` — Leaflet map helpers
 - `web/src/js/export.js` — download helper for export API
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-gdns is configured via a YAML file (default: `config.yaml` in the working directory) and/or environment variables. Environment variables take precedence over the config file.
+dnsmon is configured via a YAML file (default: `config.yaml` in the working directory) and/or environment variables. Environment variables take precedence over the config file.
 
 Pass a config file path with `--config /path/to/config.yaml`.
 
@@ -12,10 +12,10 @@ HTTP server settings.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `listen` | string | `:8080` | `GDNS_SERVER_LISTEN` | TCP address to listen on. Examples: `:8080`, `0.0.0.0:9090`, `127.0.0.1:8080` |
-| `base_url` | string | `http://localhost:8080` | `GDNS_SERVER_BASE_URL` | Public-facing base URL. Used to construct permalink URLs returned in API responses. Include scheme and host, no trailing slash. |
-| `read_timeout` | duration | `10s` | `GDNS_SERVER_READ_TIMEOUT` | Maximum duration to read the entire request, including body. Prevents slowloris attacks. |
-| `write_timeout` | duration | `30s` | `GDNS_SERVER_WRITE_TIMEOUT` | Maximum duration to write the entire response. Set this longer than the maximum expected DNS fan-out time. |
+| `listen` | string | `:8080` | `DNSMON_SERVER_LISTEN` | TCP address to listen on. Examples: `:8080`, `0.0.0.0:9090`, `127.0.0.1:8080` |
+| `base_url` | string | `http://localhost:8080` | `DNSMON_SERVER_BASE_URL` | Public-facing base URL. Used to construct permalink URLs returned in API responses. Include scheme and host, no trailing slash. |
+| `read_timeout` | duration | `10s` | `DNSMON_SERVER_READ_TIMEOUT` | Maximum duration to read the entire request, including body. Prevents slowloris attacks. |
+| `write_timeout` | duration | `30s` | `DNSMON_SERVER_WRITE_TIMEOUT` | Maximum duration to write the entire response. Set this longer than the maximum expected DNS fan-out time. |
 
 ---
 
@@ -25,10 +25,10 @@ Controls outbound DNS query behavior.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `query_timeout` | duration | `3s` | `GDNS_DNS_QUERY_TIMEOUT` | Timeout per individual DNS query to a single resolver. Resolvers that don't respond within this window are marked as `timeout`. |
-| `per_resolver_concurrency` | int | `4` | `GDNS_DNS_PER_RESOLVER_CONCURRENCY` | Maximum number of simultaneous outbound DNS queries per propagation check. Higher values reduce total check time at the cost of network bandwidth. |
-| `default_protocol` | string | `udp` | `GDNS_DNS_DEFAULT_PROTOCOL` | Default transport protocol. Options: `udp`, `tcp`, `dot` (DNS-over-TLS), `doh` (DNS-over-HTTPS). Overridable per-request in the API. |
-| `retry` | int | `1` | `GDNS_DNS_RETRY` | Number of times to retry a failed query before marking as error. `0` means no retries. |
+| `query_timeout` | duration | `3s` | `DNSMON_DNS_QUERY_TIMEOUT` | Timeout per individual DNS query to a single resolver. Resolvers that don't respond within this window are marked as `timeout`. |
+| `per_resolver_concurrency` | int | `4` | `DNSMON_DNS_PER_RESOLVER_CONCURRENCY` | Maximum number of simultaneous outbound DNS queries per propagation check. Higher values reduce total check time at the cost of network bandwidth. |
+| `default_protocol` | string | `udp` | `DNSMON_DNS_DEFAULT_PROTOCOL` | Default transport protocol. Options: `udp`, `tcp`, `dot` (DNS-over-TLS), `doh` (DNS-over-HTTPS). Overridable per-request in the API. |
+| `retry` | int | `1` | `DNSMON_DNS_RETRY` | Number of times to retry a failed query before marking as error. `0` means no retries. |
 
 ---
 
@@ -38,9 +38,9 @@ Resolver registry settings.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `builtin` | bool | `true` | `GDNS_RESOLVERS_BUILTIN` | Whether to include the built-in curated resolver list (~100 global resolvers shipped with the binary). Set to `false` to use only resolvers from `file`. |
-| `file` | string | `` | `GDNS_RESOLVERS_FILE` | Optional path to a YAML or JSON file containing additional or replacement resolvers. Each entry must match the `Resolver` type (id, name, ip, port, protocol, country, city, lat, lng). |
-| `countries` | []string | `[]` | `GDNS_RESOLVERS_COUNTRIES` | Optional ISO-3166 alpha-2 country code whitelist. If set, only resolvers located in the listed countries are used. Useful for regional deployments. Example: `[US, DE, JP]`. Env: comma-separated string. |
+| `builtin` | bool | `true` | `DNSMON_RESOLVERS_BUILTIN` | Whether to include the built-in curated resolver list (~100 global resolvers shipped with the binary). Set to `false` to use only resolvers from `file`. |
+| `file` | string | `` | `DNSMON_RESOLVERS_FILE` | Optional path to a YAML or JSON file containing additional or replacement resolvers. Each entry must match the `Resolver` type (id, name, ip, port, protocol, country, city, lat, lng). |
+| `countries` | []string | `[]` | `DNSMON_RESOLVERS_COUNTRIES` | Optional ISO-3166 alpha-2 country code whitelist. If set, only resolvers located in the listed countries are used. Useful for regional deployments. Example: `[US, DE, JP]`. Env: comma-separated string. |
 
 ---
 
@@ -50,9 +50,9 @@ Persistent storage for check history and permalinks.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `driver` | string | `sqlite` | `GDNS_STORAGE_DRIVER` | Storage backend. Options: `sqlite` (pure-Go, zero external deps), `postgres` (production-grade), `none` (disable persistence — no history, no permalinks). |
-| `dsn` | string | `file:./gdns.db?cache=shared&_fk=1` | `GDNS_STORAGE_DSN` | Data source name for the selected driver. SQLite: `file:/path/to/gdns.db?cache=shared&_fk=1`. Postgres: `postgres://user:pass@host:5432/dbname?sslmode=disable`. |
-| `retention_days` | int | `30` | `GDNS_STORAGE_RETENTION_DAYS` | Automatically delete saved checks older than this many days. A background job runs at startup and periodically. Set to `0` to disable auto-purge. |
+| `driver` | string | `sqlite` | `DNSMON_STORAGE_DRIVER` | Storage backend. Options: `sqlite` (pure-Go, zero external deps), `postgres` (production-grade), `none` (disable persistence — no history, no permalinks). |
+| `dsn` | string | `file:./dnsmon.db?cache=shared&_fk=1` | `DNSMON_STORAGE_DSN` | Data source name for the selected driver. SQLite: `file:/path/to/dnsmon.db?cache=shared&_fk=1`. Postgres: `postgres://user:pass@host:5432/dbname?sslmode=disable`. |
+| `retention_days` | int | `30` | `DNSMON_STORAGE_RETENTION_DAYS` | Automatically delete saved checks older than this many days. A background job runs at startup and periodically. Set to `0` to disable auto-purge. |
 
 ---
 
@@ -62,10 +62,10 @@ Response caching to reduce redundant DNS queries for popular domains.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `driver` | string | `memory` | `GDNS_CACHE_DRIVER` | Cache backend. Options: `memory` (in-process LRU, default), `redis` (shared cache for multi-replica deployments), `none` (disable caching). |
-| `ttl` | duration | `60s` | `GDNS_CACHE_TTL` | How long a cached `(name, type, resolver)` response is considered fresh. After expiry the next request triggers a fresh DNS query. |
-| `size` | int | `10000` | `GDNS_CACHE_SIZE` | Maximum number of entries in the in-memory LRU cache. Only applies when `driver=memory`. When capacity is exceeded, least-recently-used entries are evicted. |
-| `redis_addr` | string | `` | `GDNS_CACHE_REDIS_ADDR` | Redis server address. Only used when `driver=redis`. Format: `host:port`, e.g. `localhost:6379`. |
+| `driver` | string | `memory` | `DNSMON_CACHE_DRIVER` | Cache backend. Options: `memory` (in-process LRU, default), `redis` (shared cache for multi-replica deployments), `none` (disable caching). |
+| `ttl` | duration | `60s` | `DNSMON_CACHE_TTL` | How long a cached `(name, type, resolver)` response is considered fresh. After expiry the next request triggers a fresh DNS query. |
+| `size` | int | `10000` | `DNSMON_CACHE_SIZE` | Maximum number of entries in the in-memory LRU cache. Only applies when `driver=memory`. When capacity is exceeded, least-recently-used entries are evicted. |
+| `redis_addr` | string | `` | `DNSMON_CACHE_REDIS_ADDR` | Redis server address. Only used when `driver=redis`. Format: `host:port`, e.g. `localhost:6379`. |
 
 ---
 
@@ -75,9 +75,9 @@ Per-IP and per-API-key request throttling.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `enabled` | bool | `true` | `GDNS_RATELIMIT_ENABLED` | Whether rate limiting is active. Set to `false` in private/trusted environments. |
-| `anon_per_min` | int | `30` | `GDNS_RATELIMIT_ANON_PER_MIN` | Maximum requests per minute for anonymous (unauthenticated) callers, bucketed per IP address. Burst allowance is `ceil(anon_per_min / 3)`. |
-| `key_per_min` | int | `600` | `GDNS_RATELIMIT_KEY_PER_MIN` | Maximum requests per minute for API key holders. Admin keys are unlimited. |
+| `enabled` | bool | `true` | `DNSMON_RATELIMIT_ENABLED` | Whether rate limiting is active. Set to `false` in private/trusted environments. |
+| `anon_per_min` | int | `30` | `DNSMON_RATELIMIT_ANON_PER_MIN` | Maximum requests per minute for anonymous (unauthenticated) callers, bucketed per IP address. Burst allowance is `ceil(anon_per_min / 3)`. |
+| `key_per_min` | int | `600` | `DNSMON_RATELIMIT_KEY_PER_MIN` | Maximum requests per minute for API key holders. Admin keys are unlimited. |
 
 ---
 
@@ -87,8 +87,8 @@ Optional MaxMind GeoLite2 integration for geolocating custom resolvers. The buil
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `enabled` | bool | `false` | `GDNS_GEOIP_ENABLED` | Whether to enable GeoIP lookups. Requires `mmdb_path` to be set. |
-| `mmdb_path` | string | `` | `GDNS_GEOIP_MMDB_PATH` | Absolute path to a MaxMind GeoLite2-City `.mmdb` database file. Obtain a free copy from [maxmind.com](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data). |
+| `enabled` | bool | `false` | `DNSMON_GEOIP_ENABLED` | Whether to enable GeoIP lookups. Requires `mmdb_path` to be set. |
+| `mmdb_path` | string | `` | `DNSMON_GEOIP_MMDB_PATH` | Absolute path to a MaxMind GeoLite2-City `.mmdb` database file. Obtain a free copy from [maxmind.com](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data). |
 
 ---
 
@@ -98,8 +98,8 @@ Logging configuration.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `level` | string | `info` | `GDNS_LOG_LEVEL` | Minimum log level. Options: `debug`, `info`, `warn`, `error`. Use `debug` for verbose output during development. |
-| `format` | string | `json` | `GDNS_LOG_FORMAT` | Log output format. `json` produces structured JSON (recommended for log aggregation). `text` produces human-readable output for local development. |
+| `level` | string | `info` | `DNSMON_LOG_LEVEL` | Minimum log level. Options: `debug`, `info`, `warn`, `error`. Use `debug` for verbose output during development. |
+| `format` | string | `json` | `DNSMON_LOG_FORMAT` | Log output format. `json` produces structured JSON (recommended for log aggregation). `text` produces human-readable output for local development. |
 
 ---
 
@@ -109,8 +109,8 @@ Prometheus metrics exposure.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `enabled` | bool | `true` | `GDNS_METRICS_ENABLED` | Whether to expose the Prometheus metrics endpoint. |
-| `path` | string | `/metrics` | `GDNS_METRICS_PATH` | HTTP path at which Prometheus metrics are served. Note: this path is outside `/api/v1`. |
+| `enabled` | bool | `true` | `DNSMON_METRICS_ENABLED` | Whether to expose the Prometheus metrics endpoint. |
+| `path` | string | `/metrics` | `DNSMON_METRICS_PATH` | HTTP path at which Prometheus metrics are served. Note: this path is outside `/api/v1`. |
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to gdns
+# Contributing to dnsmon
 
-Thank you for your interest in contributing to gdns! This document covers how to set up the development environment, our branching strategy, commit conventions, and the pull request checklist.
+Thank you for your interest in contributing to dnsmon! This document covers how to set up the development environment, our branching strategy, commit conventions, and the pull request checklist.
 
 ---
 
@@ -16,8 +16,8 @@ Thank you for your interest in contributing to gdns! This document covers how to
 ### Clone and build
 
 ```bash
-git clone https://github.com/tomerklein/gdns.git
-cd gdns
+git clone https://github.com/t0mer/dnsmon.git
+cd dnsmon
 
 # Install frontend build deps
 cd web && npm ci && cd ..
@@ -38,9 +38,9 @@ make dev
 ### Running the server locally
 
 ```bash
-./bin/gdns --config config/config.example.yaml
+./bin/dnsmon --config config/config.example.yaml
 # or with env vars:
-GDNS_STORAGE_DRIVER=none GDNS_CACHE_DRIVER=memory ./bin/gdns
+DNSMON_STORAGE_DRIVER=none DNSMON_CACHE_DRIVER=memory ./bin/dnsmon
 ```
 
 Open http://localhost:8080.
@@ -186,7 +186,7 @@ Before adding a new Go dependency:
 ## Reporting Issues
 
 Open a GitHub issue with:
-- gdns version (`./bin/gdns --version`)
+- dnsmon version (`./bin/dnsmon --version`)
 - Steps to reproduce
 - Expected vs. actual behavior
 - Relevant log output (sanitize any sensitive data)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,16 +1,16 @@
 # Deployment Guide
 
-This guide covers deploying gdns in various environments.
+This guide covers deploying dnsmon in various environments.
 
 ---
 
 ## Quick Start — Docker Compose (SQLite)
 
-The simplest way to run gdns. Data persists in a named Docker volume.
+The simplest way to run dnsmon. Data persists in a named Docker volume.
 
 ```bash
-git clone https://github.com/tomerklein/gdns.git
-cd gdns
+git clone https://github.com/t0mer/dnsmon.git
+cd dnsmon
 docker compose -f deploy/docker-compose.sqlite.yml up -d
 ```
 
@@ -28,13 +28,13 @@ docker compose -f deploy/docker-compose.yml up -d
 ```
 
 This starts three containers:
-- `gdns` — the Go binary
+- `dnsmon` — the Go binary
 - `postgres:16-alpine` — persistent check history
 - `redis:7-alpine` — distributed cache and rate-limit state
 
 Check logs:
 ```bash
-docker compose -f deploy/docker-compose.yml logs -f gdns
+docker compose -f deploy/docker-compose.yml logs -f dnsmon
 ```
 
 ---
@@ -52,22 +52,22 @@ kubectl apply -f deploy/k8s/ingress.yaml
 The Ingress assumes:
 - `ingress-nginx` is installed in the cluster.
 - `cert-manager` is installed and a `ClusterIssuer` named `letsencrypt-prod` exists.
-- You update `gdns.example.com` to your real hostname.
+- You update `dnsmon.example.com` to your real hostname.
 
-For custom configuration, mount a ConfigMap as `/etc/gdns/config.yaml` and set the
+For custom configuration, mount a ConfigMap as `/etc/dnsmon/config.yaml` and set the
 `--config` flag:
 
 ```yaml
 # In deployment.yaml, add to spec.containers[0]:
-args: ["--config", "/etc/gdns/config.yaml"]
+args: ["--config", "/etc/dnsmon/config.yaml"]
 volumeMounts:
   - name: config
-    mountPath: /etc/gdns
+    mountPath: /etc/dnsmon
     readOnly: true
 volumes:
   - name: config
     configMap:
-      name: gdns-config
+      name: dnsmon-config
 ```
 
 ### Persistent storage on Kubernetes
@@ -81,13 +81,13 @@ volumeMounts:
 volumes:
   - name: data
     persistentVolumeClaim:
-      claimName: gdns-data
+      claimName: dnsmon-data
 ```
 
 For Postgres, deploy a separate Postgres instance (or use a managed database) and set:
 ```
-GDNS_STORAGE_DRIVER=postgres
-GDNS_STORAGE_DSN=postgres://user:pass@host:5432/gdns?sslmode=require
+DNSMON_STORAGE_DRIVER=postgres
+DNSMON_STORAGE_DSN=postgres://user:pass@host:5432/dnsmon?sslmode=require
 ```
 
 ---
@@ -96,56 +96,56 @@ GDNS_STORAGE_DSN=postgres://user:pass@host:5432/gdns?sslmode=require
 
 1. **Install the binary:**
    ```bash
-   sudo cp bin/gdns /usr/local/bin/gdns
-   sudo chmod +x /usr/local/bin/gdns
+   sudo cp bin/dnsmon /usr/local/bin/dnsmon
+   sudo chmod +x /usr/local/bin/dnsmon
    ```
 
 2. **Create a dedicated user:**
    ```bash
-   sudo useradd --system --no-create-home --shell /usr/sbin/nologin gdns
+   sudo useradd --system --no-create-home --shell /usr/sbin/nologin dnsmon
    ```
 
 3. **Create config directory and file:**
    ```bash
-   sudo mkdir -p /etc/gdns
-   sudo cp config/config.example.yaml /etc/gdns/config.yaml
-   sudo chown -R gdns:gdns /etc/gdns
+   sudo mkdir -p /etc/dnsmon
+   sudo cp config/config.example.yaml /etc/dnsmon/config.yaml
+   sudo chown -R dnsmon:dnsmon /etc/dnsmon
    ```
 
 4. **Install the systemd unit:**
    ```bash
-   sudo cp deploy/systemd/gdns.service /etc/systemd/system/
+   sudo cp deploy/systemd/dnsmon.service /etc/systemd/system/
    sudo systemctl daemon-reload
-   sudo systemctl enable --now gdns
+   sudo systemctl enable --now dnsmon
    ```
 
 5. **Check status:**
    ```bash
-   sudo systemctl status gdns
-   sudo journalctl -u gdns -f
+   sudo systemctl status dnsmon
+   sudo journalctl -u dnsmon -f
    ```
 
 ---
 
 ## Behind Nginx (Reverse Proxy)
 
-gdns expects to run behind a reverse proxy that handles TLS termination.
+dnsmon expects to run behind a reverse proxy that handles TLS termination.
 
 Minimal Nginx config:
 
 ```nginx
 server {
     listen 80;
-    server_name gdns.example.com;
+    server_name dnsmon.example.com;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name gdns.example.com;
+    server_name dnsmon.example.com;
 
-    ssl_certificate     /etc/letsencrypt/live/gdns.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/gdns.example.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/dnsmon.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dnsmon.example.com/privkey.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
@@ -176,37 +176,37 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ## Environment Variables Reference
 
-All configuration options from `config.yaml` can be overridden with `GDNS_*` environment variables. The mapping is: dots become underscores, all uppercase.
+All configuration options from `config.yaml` can be overridden with `DNSMON_*` environment variables. The mapping is: dots become underscores, all uppercase.
 
 | Variable | Default | Description |
 |---|---|---|
-| `GDNS_SERVER_LISTEN` | `:8080` | Listen address |
-| `GDNS_SERVER_BASE_URL` | `http://localhost:8080` | Public URL for permalinks |
-| `GDNS_SERVER_READ_TIMEOUT` | `10s` | HTTP read timeout |
-| `GDNS_SERVER_WRITE_TIMEOUT` | `30s` | HTTP write timeout |
-| `GDNS_DNS_QUERY_TIMEOUT` | `3s` | Per-resolver DNS query timeout |
-| `GDNS_DNS_PER_RESOLVER_CONCURRENCY` | `4` | Max concurrent outbound queries |
-| `GDNS_DNS_DEFAULT_PROTOCOL` | `udp` | Default DNS transport |
-| `GDNS_DNS_RETRY` | `1` | Query retries on failure |
-| `GDNS_RESOLVERS_BUILTIN` | `true` | Use built-in resolver list |
-| `GDNS_RESOLVERS_FILE` | `` | Path to extra resolvers file |
-| `GDNS_RESOLVERS_COUNTRIES` | `` | Country whitelist (comma-separated) |
-| `GDNS_STORAGE_DRIVER` | `sqlite` | `sqlite`, `postgres`, or `none` |
-| `GDNS_STORAGE_DSN` | (SQLite file) | Data source name |
-| `GDNS_STORAGE_RETENTION_DAYS` | `30` | Auto-delete checks older than N days |
-| `GDNS_CACHE_DRIVER` | `memory` | `memory`, `redis`, or `none` |
-| `GDNS_CACHE_TTL` | `60s` | Cache entry TTL |
-| `GDNS_CACHE_SIZE` | `10000` | LRU cache max entries (memory only) |
-| `GDNS_CACHE_REDIS_ADDR` | `` | Redis address (e.g. `localhost:6379`) |
-| `GDNS_RATELIMIT_ENABLED` | `true` | Enable rate limiting |
-| `GDNS_RATELIMIT_ANON_PER_MIN` | `30` | Anonymous req/min per IP |
-| `GDNS_RATELIMIT_KEY_PER_MIN` | `600` | API key req/min |
-| `GDNS_GEOIP_ENABLED` | `false` | Enable MaxMind GeoIP |
-| `GDNS_GEOIP_MMDB_PATH` | `` | Path to GeoLite2-City.mmdb |
-| `GDNS_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
-| `GDNS_LOG_FORMAT` | `json` | `json` or `text` |
-| `GDNS_METRICS_ENABLED` | `true` | Enable Prometheus metrics |
-| `GDNS_METRICS_PATH` | `/metrics` | Metrics endpoint path |
+| `DNSMON_SERVER_LISTEN` | `:8080` | Listen address |
+| `DNSMON_SERVER_BASE_URL` | `http://localhost:8080` | Public URL for permalinks |
+| `DNSMON_SERVER_READ_TIMEOUT` | `10s` | HTTP read timeout |
+| `DNSMON_SERVER_WRITE_TIMEOUT` | `30s` | HTTP write timeout |
+| `DNSMON_DNS_QUERY_TIMEOUT` | `3s` | Per-resolver DNS query timeout |
+| `DNSMON_DNS_PER_RESOLVER_CONCURRENCY` | `4` | Max concurrent outbound queries |
+| `DNSMON_DNS_DEFAULT_PROTOCOL` | `udp` | Default DNS transport |
+| `DNSMON_DNS_RETRY` | `1` | Query retries on failure |
+| `DNSMON_RESOLVERS_BUILTIN` | `true` | Use built-in resolver list |
+| `DNSMON_RESOLVERS_FILE` | `` | Path to extra resolvers file |
+| `DNSMON_RESOLVERS_COUNTRIES` | `` | Country whitelist (comma-separated) |
+| `DNSMON_STORAGE_DRIVER` | `sqlite` | `sqlite`, `postgres`, or `none` |
+| `DNSMON_STORAGE_DSN` | (SQLite file) | Data source name |
+| `DNSMON_STORAGE_RETENTION_DAYS` | `30` | Auto-delete checks older than N days |
+| `DNSMON_CACHE_DRIVER` | `memory` | `memory`, `redis`, or `none` |
+| `DNSMON_CACHE_TTL` | `60s` | Cache entry TTL |
+| `DNSMON_CACHE_SIZE` | `10000` | LRU cache max entries (memory only) |
+| `DNSMON_CACHE_REDIS_ADDR` | `` | Redis address (e.g. `localhost:6379`) |
+| `DNSMON_RATELIMIT_ENABLED` | `true` | Enable rate limiting |
+| `DNSMON_RATELIMIT_ANON_PER_MIN` | `30` | Anonymous req/min per IP |
+| `DNSMON_RATELIMIT_KEY_PER_MIN` | `600` | API key req/min |
+| `DNSMON_GEOIP_ENABLED` | `false` | Enable MaxMind GeoIP |
+| `DNSMON_GEOIP_MMDB_PATH` | `` | Path to GeoLite2-City.mmdb |
+| `DNSMON_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
+| `DNSMON_LOG_FORMAT` | `json` | `json` or `text` |
+| `DNSMON_METRICS_ENABLED` | `true` | Enable Prometheus metrics |
+| `DNSMON_METRICS_PATH` | `/metrics` | Metrics endpoint path |
 
 ---
 
@@ -216,8 +216,8 @@ Requirements: Go 1.23+, Node.js 20+ (build-time only).
 
 ```bash
 # Clone
-git clone https://github.com/tomerklein/gdns.git
-cd gdns
+git clone https://github.com/t0mer/dnsmon.git
+cd dnsmon
 
 # Build UI (Tailwind CSS)
 make ui
@@ -226,7 +226,7 @@ make ui
 make build
 
 # Run
-./bin/gdns --config config/config.example.yaml
+./bin/dnsmon --config config/config.example.yaml
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tomerklein/gdns
+module github.com/t0mer/dnsmon
 
 go 1.25.0
 

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: gdns API
+  title: dnsmon API
   description: Self-hosted DNS propagation checker API
   version: 1.0.0
   license:

--- a/internal/api/docs/swagger.go
+++ b/internal/api/docs/swagger.go
@@ -14,7 +14,7 @@ const swaggerUIHTML = `<!DOCTYPE html>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>gdns API Docs</title>
+  <title>dnsmon API Docs</title>
   <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
 </head>
 <body>

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/tomerklein/gdns/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
 )
 
 // Re-export constants for callers that import api directly.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,13 +7,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/tomerklein/gdns/internal/api/docs"
-	v1 "github.com/tomerklein/gdns/internal/api/v1"
-	"github.com/tomerklein/gdns/internal/checker"
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/resolvers"
-	"github.com/tomerklein/gdns/internal/storage"
-	"github.com/tomerklein/gdns/web"
+	"github.com/t0mer/dnsmon/internal/api/docs"
+	v1 "github.com/t0mer/dnsmon/internal/api/v1"
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/storage"
+	"github.com/t0mer/dnsmon/web"
 )
 
 // Server holds the HTTP router and its dependencies.

--- a/internal/api/v1/check.go
+++ b/internal/api/v1/check.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/checker"
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 var (

--- a/internal/api/v1/export.go
+++ b/internal/api/v1/export.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/export"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/export"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 // ExportCheck handles GET /api/v1/check/{id}/export?format=json|csv|png|svg|pdf.
@@ -33,7 +33,7 @@ func ExportCheck(store storage.Storage) http.HandlerFunc {
 			return
 		}
 
-		filename := fmt.Sprintf("gdns-%s-%s.%s", check.Name, check.Type, format)
+		filename := fmt.Sprintf("dnsmon-%s-%s.%s", check.Name, check.Type, format)
 
 		switch format {
 		case "json":

--- a/internal/api/v1/handlers_test.go
+++ b/internal/api/v1/handlers_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/tomerklein/gdns/internal/api/v1"
-	"github.com/tomerklein/gdns/internal/checker"
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/resolvers"
-	"github.com/tomerklein/gdns/internal/storage"
+	v1 "github.com/t0mer/dnsmon/internal/api/v1"
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 // mockDNSClient is a stub DNS client.

--- a/internal/api/v1/health.go
+++ b/internal/api/v1/health.go
@@ -3,9 +3,9 @@ package v1
 import (
 	"net/http"
 
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/storage"
-	"github.com/tomerklein/gdns/internal/version"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/storage"
+	"github.com/t0mer/dnsmon/internal/version"
 )
 
 // Health returns 200 with {"status":"ok"}.

--- a/internal/api/v1/history.go
+++ b/internal/api/v1/history.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 // ListHistory handles GET /api/v1/history.

--- a/internal/api/v1/lookup.go
+++ b/internal/api/v1/lookup.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/checker"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/checker"
 )
 
 // LookupRequest is the request body for POST /api/v1/lookup.

--- a/internal/api/v1/recordtypes.go
+++ b/internal/api/v1/recordtypes.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 type recordTypeInfo struct {

--- a/internal/api/v1/resolvers.go
+++ b/internal/api/v1/resolvers.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/resolvers"
 )
 
 // ListResolvers handles GET /api/v1/resolvers.

--- a/internal/api/v1/reverse.go
+++ b/internal/api/v1/reverse.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/checker"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/checker"
 )
 
 // ReverseRequest is the request body for POST /api/v1/reverse.

--- a/internal/api/v1/stream.go
+++ b/internal/api/v1/stream.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
-	"github.com/tomerklein/gdns/internal/api/apierr"
-	"github.com/tomerklein/gdns/internal/checker"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 type wsStreamRequest struct {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tomerklein/gdns/internal/config"
+	"github.com/t0mer/dnsmon/internal/config"
 )
 
 // Cache is a key-value store for DNS query results.

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/tomerklein/gdns/internal/cache"
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/resolvers"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/cache"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 const maxResolvers = 200
@@ -62,24 +62,24 @@ func registerOrGet[C prometheus.Collector](c C) C {
 func newMetrics() *metrics {
 	return &metrics{
 		checkTotal: registerOrGet(prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "gdns_check_total",
+			Name: "dnsmon_check_total",
 			Help: "Total DNS propagation checks.",
 		}, []string{"type", "status"})),
 		queryDuration: registerOrGet(prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "gdns_resolver_query_duration_seconds",
+			Name:    "dnsmon_resolver_query_duration_seconds",
 			Help:    "DNS query duration in seconds per resolver.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"resolver_id", "status"})),
 		queryTotal: registerOrGet(prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "gdns_resolver_query_total",
+			Name: "dnsmon_resolver_query_total",
 			Help: "Total DNS queries per resolver.",
 		}, []string{"resolver_id", "status"})),
 		cacheHits: registerOrGet(prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "gdns_cache_hits_total",
+			Name: "dnsmon_cache_hits_total",
 			Help: "Total cache hits.",
 		})),
 		cacheMisses: registerOrGet(prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "gdns_cache_misses_total",
+			Name: "dnsmon_cache_misses_total",
 			Help: "Total cache misses.",
 		})),
 	}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tomerklein/gdns/internal/cache"
-	"github.com/tomerklein/gdns/internal/checker"
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/resolvers"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/cache"
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 // mockClient is a fake DNS client for testing.

--- a/internal/checker/stream.go
+++ b/internal/checker/stream.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tomerklein/gdns/internal/cache"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/cache"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 // StreamRequest describes a streaming DNS propagation check.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,14 +85,14 @@ type MetricsConfig struct {
 }
 
 // Load reads configuration from cfgFile (if non-empty) or from default search
-// paths, merges environment variables with the GDNS_ prefix, and returns the
+// paths, merges environment variables with the DNSMON_ prefix, and returns the
 // parsed Config.
 func Load(cfgFile string) (*Config, error) {
 	v := viper.New()
 
 	setDefaults(v)
 
-	v.SetEnvPrefix("GDNS")
+	v.SetEnvPrefix("DNSMON")
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
@@ -102,8 +102,8 @@ func Load(cfgFile string) (*Config, error) {
 		v.SetConfigName("config")
 		v.SetConfigType("yaml")
 		v.AddConfigPath(".")
-		v.AddConfigPath("$HOME/.gdns")
-		v.AddConfigPath("/etc/gdns")
+		v.AddConfigPath("$HOME/.dnsmon")
+		v.AddConfigPath("/etc/dnsmon")
 	}
 
 	if err := v.ReadInConfig(); err != nil {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -15,7 +15,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("resolvers.builtin", true)
 
 	v.SetDefault("storage.driver", "sqlite")
-	v.SetDefault("storage.dsn", "file:./gdns.db?cache=shared&_fk=1")
+	v.SetDefault("storage.dsn", "file:./dnsmon.db?cache=shared&_fk=1")
 	v.SetDefault("storage.retention_days", 30)
 
 	v.SetDefault("cache.driver", "memory")

--- a/internal/dnsclient/client.go
+++ b/internal/dnsclient/client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/tomerklein/gdns/internal/config"
+	"github.com/t0mer/dnsmon/internal/config"
 )
 
 // Client performs DNS queries.

--- a/internal/dnsclient/client_test.go
+++ b/internal/dnsclient/client_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 func newTestConfig(timeout time.Duration) *config.Config {

--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 // CSV writes a Check's results as CSV to w.

--- a/internal/export/pdf.go
+++ b/internal/export/pdf.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/jung-kurt/gofpdf"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 // PDF writes a Check's results as PDF to w.
@@ -15,7 +15,7 @@ func PDF(w io.Writer, check *dnsclient.Check) error {
 	pdf.SetFont("Helvetica", "B", 16)
 
 	// Title
-	pdf.CellFormat(0, 10, "gdns DNS Propagation Report", "", 1, "C", false, 0, "")
+	pdf.CellFormat(0, 10, "dnsmon DNS Propagation Report", "", 1, "C", false, 0, "")
 	pdf.Ln(4)
 
 	// Metadata

--- a/internal/export/png.go
+++ b/internal/export/png.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/fogleman/gg"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 const (

--- a/internal/export/svg.go
+++ b/internal/export/svg.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 const (
@@ -75,7 +75,7 @@ func SVG(w io.Writer, check *dnsclient.Check) error {
 
 	// Title
 	b.WriteString(fmt.Sprintf(
-		`<text x="10" y="20" fill="#e2e8f0" font-family="sans-serif" font-size="14" font-weight="bold">gdns: %s %s</text>`,
+		`<text x="10" y="20" fill="#e2e8f0" font-family="sans-serif" font-size="14" font-weight="bold">dnsmon: %s %s</text>`,
 		escapeXML(check.Name), escapeXML(check.Type),
 	))
 

--- a/internal/geoip/geoip_test.go
+++ b/internal/geoip/geoip_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tomerklein/gdns/internal/geoip"
+	"github.com/t0mer/dnsmon/internal/geoip"
 )
 
 func TestOpen_MissingFile(t *testing.T) {

--- a/internal/resolvers/builtin.go
+++ b/internal/resolvers/builtin.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 //go:embed resolvers.json

--- a/internal/resolvers/registry.go
+++ b/internal/resolvers/registry.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tomerklein/gdns/internal/config"
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 // Registry holds the set of known resolvers.

--- a/internal/resolvers/resolvers.go
+++ b/internal/resolvers/resolvers.go
@@ -3,7 +3,7 @@ package resolvers
 import (
 	"fmt"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 // DefaultPort is the standard DNS port.

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -12,8 +12,8 @@ import (
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 //go:embed migrations/*.sql

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -13,8 +13,8 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
-	"github.com/tomerklein/gdns/internal/storage"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 //go:embed migrations/*.sql

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/tomerklein/gdns/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
 // ErrNotFound is returned when a requested record does not exist.

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-integration.sh — Smoke tests the gdns HTTP API against a locally running server.
+# test-integration.sh — Smoke tests the dnsmon HTTP API against a locally running server.
 # Starts the binary with SQLite in a temp dir, runs a basic propagation check,
 # and verifies the response shape.
 #
@@ -11,7 +11,7 @@ set -euo pipefail
 ###############################################################################
 # Configuration
 ###############################################################################
-BINARY="${BINARY:-./bin/gdns}"
+BINARY="${BINARY:-./bin/dnsmon}"
 PORT="${PORT:-18080}"
 BASE_URL="http://localhost:${PORT}"
 TMPDIR=$(mktemp -d)
@@ -48,14 +48,14 @@ trap cleanup EXIT
 ###############################################################################
 # Start server
 ###############################################################################
-echo "Starting gdns on port $PORT with SQLite in $TMPDIR ..."
-GDNS_SERVER_LISTEN=":${PORT}" \
-GDNS_STORAGE_DRIVER="sqlite" \
-GDNS_STORAGE_DSN="file:${TMPDIR}/gdns.db?cache=shared&_fk=1" \
-GDNS_CACHE_DRIVER="memory" \
-GDNS_LOG_FORMAT="text" \
-GDNS_LOG_LEVEL="warn" \
-GDNS_METRICS_ENABLED="false" \
+echo "Starting dnsmon on port $PORT with SQLite in $TMPDIR ..."
+DNSMON_SERVER_LISTEN=":${PORT}" \
+DNSMON_STORAGE_DRIVER="sqlite" \
+DNSMON_STORAGE_DSN="file:${TMPDIR}/dnsmon.db?cache=shared&_fk=1" \
+DNSMON_CACHE_DRIVER="memory" \
+DNSMON_LOG_FORMAT="text" \
+DNSMON_LOG_LEVEL="warn" \
+DNSMON_METRICS_ENABLED="false" \
   "$BINARY" &
 SERVER_PID=$!
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gdns-web",
+  "name": "dnsmon-web",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gdns-web",
+      "name": "dnsmon-web",
       "version": "1.0.0",
       "devDependencies": {
         "autoprefixer": "^10.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gdns-web",
+  "name": "dnsmon-web",
   "version": "1.0.0",
   "private": true,
   "devDependencies": {

--- a/web/src/about.html
+++ b/web/src/about.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>gdns — About</title>
-  <meta name="description" content="About gdns — a self-hosted, open-source DNS propagation checker built with Go." />
+  <title>dnsmon — About</title>
+  <meta name="description" content="About dnsmon — a self-hosted, open-source DNS propagation checker built with Go." />
   <link rel="stylesheet" href="/css/app.css" />
 </head>
 <body class="min-h-screen">
@@ -15,11 +15,11 @@
       <div class="flex items-center justify-between h-14">
 
         <!-- Logo -->
-        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="gdns home">
+        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="dnsmon home">
           <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
           </svg>
-          <span>gdns</span>
+          <span>dnsmon</span>
         </a>
 
         <!-- Desktop links -->
@@ -49,7 +49,7 @@
           <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
         </svg>
       </div>
-      <h1 class="text-2xl sm:text-3xl font-bold text-white mb-2">About gdns</h1>
+      <h1 class="text-2xl sm:text-3xl font-bold text-white mb-2">About dnsmon</h1>
       <p class="text-indigo-200 dark:text-indigo-300 text-sm sm:text-base max-w-xl mx-auto">
         A free, open-source, self-hosted alternative to <a href="https://www.whatsmydns.net" target="_blank" rel="noopener noreferrer" class="text-white underline underline-offset-2 hover:no-underline">whatsmydns.net</a> — built with Go.
       </p>
@@ -59,11 +59,11 @@
   <!-- Main content -->
   <main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-5">
 
-    <!-- What is gdns -->
+    <!-- What is dnsmon -->
     <div class="card card-body">
-      <h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">What is gdns?</h2>
+      <h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">What is dnsmon?</h2>
       <p class="text-slate-600 dark:text-slate-400 leading-relaxed mb-3 text-sm">
-        <strong class="text-slate-900 dark:text-white">gdns</strong> is an open-source DNS propagation checker you can run inside
+        <strong class="text-slate-900 dark:text-white">dnsmon</strong> is an open-source DNS propagation checker you can run inside
         your own infrastructure. It queries 100+ global public DNS resolvers in parallel and shows you how a DNS record is
         resolving around the world — in real time.
       </p>
@@ -139,13 +139,13 @@
     <div class="card card-body">
       <h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">Deploy in 30 seconds</h2>
       <p class="text-slate-600 dark:text-slate-400 text-sm mb-4">
-        Run gdns with a single command using Docker Compose:
+        Run dnsmon with a single command using Docker Compose:
       </p>
       <pre class="bg-slate-900 dark:bg-slate-950 text-emerald-400 text-sm font-mono p-4 rounded-xl overflow-x-auto ring-1 ring-slate-800"><code>docker compose -f deploy/docker-compose.sqlite.yml up -d</code></pre>
       <p class="text-sm text-slate-500 dark:text-slate-400 mt-3">
         Then open <strong class="font-mono text-slate-700 dark:text-slate-300">http://localhost:8080</strong> in your browser.
         For production deployments with Postgres and Redis, see the
-        <a href="https://github.com/tomerklein/gdns/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener noreferrer"
+        <a href="https://github.com/t0mer/dnsmon/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener noreferrer"
           class="text-indigo-600 dark:text-indigo-400 hover:underline">deployment guide</a>.
       </p>
     </div>
@@ -193,7 +193,7 @@
     <div class="card card-body">
       <h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Links</h2>
       <div class="flex flex-col sm:flex-row gap-3">
-        <a href="https://github.com/tomerklein/gdns" target="_blank" rel="noopener noreferrer"
+        <a href="https://github.com/t0mer/dnsmon" target="_blank" rel="noopener noreferrer"
           class="btn-primary flex items-center justify-center gap-2">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
@@ -217,12 +217,12 @@
       <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400 dark:text-slate-500">
         <div class="flex items-center gap-2">
           <svg class="w-5 h-5 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          <span class="font-medium text-slate-600 dark:text-slate-300">gdns</span>
+          <span class="font-medium text-slate-600 dark:text-slate-300">dnsmon</span>
           <span>&#8212; Self-hosted DNS propagation checker. MIT License.</span>
         </div>
         <div class="flex items-center gap-4">
           <a href="/about" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">About</a>
-          <a href="https://github.com/tomerklein/gdns" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/t0mer/dnsmon" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="/api-docs" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">API</a>
         </div>
       </div>

--- a/web/src/api-docs.html
+++ b/web/src/api-docs.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>gdns API Documentation</title>
+  <title>dnsmon API Documentation</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -291,7 +291,11 @@
               <div class="flex items-start justify-between gap-2">
                 <!-- Left: flag + resolver info -->
                 <div class="flex items-center gap-2 min-w-0">
-                  <span class="text-xl flex-shrink-0" x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                  <span class="relative flex-shrink-0 group cursor-default">
+                    <span class="text-xl" x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                    <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
+                      x-text="countryName(result.resolver.country)"></span>
+                  </span>
                   <div class="min-w-0">
                     <div class="font-medium text-slate-900 dark:text-white text-sm truncate" x-text="result.resolver.name"></div>
                     <div class="text-xs text-slate-500 dark:text-slate-400 font-mono" x-text="result.resolver.ip"></div>
@@ -324,8 +328,14 @@
                 </template>
               </div>
               <!-- Location -->
-              <div class="mt-1 ml-9 text-xs text-slate-400 dark:text-slate-500"
-                x-text="[result.resolver.city, result.resolver.country].filter(Boolean).join(', ')"></div>
+              <div class="mt-1 ml-9 text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1">
+                <span class="relative group cursor-default">
+                  <span x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                  <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
+                    x-text="countryName(result.resolver.country)"></span>
+                </span>
+                <span x-text="result.resolver.city || ''"></span>
+              </div>
             </div>
           </template>
         </div>
@@ -365,7 +375,11 @@
                 <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/30 transition-colors animate-fade-in">
                   <!-- Flag -->
                   <td class="px-4 py-3">
-                    <span class="text-xl" x-text="countryFlag(result.resolver.country)" :title="result.resolver.country" aria-hidden="true"></span>
+                    <span class="relative inline-block group cursor-default">
+                      <span class="text-xl" x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                      <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
+                        x-text="countryName(result.resolver.country)"></span>
+                    </span>
                   </td>
                   <!-- Resolver -->
                   <td class="px-4 py-3">
@@ -374,7 +388,7 @@
                   </td>
                   <!-- Location -->
                   <td class="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs">
-                    <span x-text="[result.resolver.city, result.resolver.country].filter(Boolean).join(', ')"></span>
+                    <span x-text="result.resolver.city || '—'"></span>
                   </td>
                   <!-- Status badge -->
                   <td class="px-4 py-3">

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>gdns — DNS Propagation Checker</title>
+  <title>dnsmon — DNS Propagation Checker</title>
   <meta name="description" content="Self-hosted DNS propagation checker. Check how DNS is resolving across 100+ global resolvers." />
   <link rel="stylesheet" href="/css/app.css" />
   <!-- Leaflet -->
@@ -24,11 +24,11 @@
       <div class="flex items-center justify-between h-14">
 
         <!-- Logo -->
-        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="gdns home">
+        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="dnsmon home">
           <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
           </svg>
-          <span>gdns</span>
+          <span>dnsmon</span>
         </a>
 
         <!-- Desktop links -->
@@ -66,7 +66,7 @@
   </nav>
 
   <!-- Main content -->
-  <main x-data="gdnsApp()">
+  <main x-data="dnsmonApp()">
 
     <!-- HERO (gradient bg) -->
     <div class="bg-gradient-to-br from-indigo-600 via-indigo-700 to-violet-800 dark:from-indigo-950 dark:via-slate-950 dark:to-violet-950">
@@ -482,12 +482,12 @@
       <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400 dark:text-slate-500">
         <div class="flex items-center gap-2">
           <svg class="w-5 h-5 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          <span class="font-medium text-slate-600 dark:text-slate-300">gdns</span>
+          <span class="font-medium text-slate-600 dark:text-slate-300">dnsmon</span>
           <span>&#8212; Self-hosted DNS propagation checker</span>
         </div>
         <div class="flex items-center gap-4">
           <a href="/about" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">About</a>
-          <a href="https://github.com/tomerklein/gdns" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/t0mer/dnsmon" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="/api-docs" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">API</a>
         </div>
       </div>

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -19,7 +19,7 @@ window.toggleDark = function toggleDark() {
 };
 
 // ---------------------------------------------------------------------------
-// Country flag helper (emoji flag from ISO-3166 alpha-2)
+// Country flag + name helpers (ISO-3166 alpha-2)
 // ---------------------------------------------------------------------------
 function countryFlag(code) {
   if (!code || code.length !== 2) return '';
@@ -27,6 +27,19 @@ function countryFlag(code) {
     (c) => 0x1f1e6 + c.charCodeAt(0) - 65
   );
   return String.fromCodePoint(...codePoints);
+}
+
+const _regionNames = (typeof Intl !== 'undefined' && Intl.DisplayNames)
+  ? new Intl.DisplayNames(['en'], { type: 'region' })
+  : null;
+
+function countryName(code) {
+  if (!code || code.length !== 2) return code || '';
+  try {
+    return _regionNames ? _regionNames.of(code.toUpperCase()) : code;
+  } catch {
+    return code;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -341,6 +354,7 @@ function dnsmonApp() {
     // Helpers exposed to templates
     // ---------------------------------------------------------------------------
     countryFlag,
+    countryName,
 
     // ---------------------------------------------------------------------------
     // Internal helpers
@@ -473,6 +487,7 @@ function reverseApp() {
     },
 
     countryFlag,
+    countryName,
   };
 }
 

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -1,4 +1,4 @@
-// app.js — Alpine.js components for gdns
+// app.js — Alpine.js components for dnsmon
 // Loaded as a plain defer script (no ES module) so it runs before Alpine initializes.
 
 // ---------------------------------------------------------------------------
@@ -30,9 +30,9 @@ function countryFlag(code) {
 }
 
 // ---------------------------------------------------------------------------
-// gdnsApp — DNS Propagation Checker (index.html)
+// dnsmonApp — DNS Propagation Checker (index.html)
 // ---------------------------------------------------------------------------
-function gdnsApp() {
+function dnsmonApp() {
   return {
     // Form state
     domain: '',
@@ -480,7 +480,7 @@ function reverseApp() {
 // Register Alpine.js components
 // ---------------------------------------------------------------------------
 document.addEventListener('alpine:init', () => {
-  Alpine.data('gdnsApp', gdnsApp);
+  Alpine.data('dnsmonApp', dnsmonApp);
   Alpine.data('lookupApp', lookupApp);
   Alpine.data('reverseApp', reverseApp);
 });

--- a/web/src/js/export.js
+++ b/web/src/js/export.js
@@ -11,7 +11,7 @@ async function exportCheck(checkId, format) {
   const objectUrl = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = objectUrl;
-  a.download = `gdns-check-${checkId}.${format}`;
+  a.download = `dnsmon-check-${checkId}.${format}`;
   a.style.display = 'none';
   document.body.appendChild(a);
   a.click();

--- a/web/src/js/map.js
+++ b/web/src/js/map.js
@@ -1,5 +1,5 @@
 /**
- * map.js — Leaflet world map helpers for gdns
+ * map.js — Leaflet world map helpers for dnsmon
  * Provides initMap() and updateMarkers() for the propagation and reverse pages.
  */
 
@@ -106,7 +106,7 @@ function updateMarkers(markerLayer, results) {
 
     // Build popup content
     const popupContent = _buildPopup(resolver, status, answers, duration_ms);
-    marker.bindPopup(popupContent, { maxWidth: 260, className: 'gdns-popup' });
+    marker.bindPopup(popupContent, { maxWidth: 260, className: 'dnsmon-popup' });
 
     // Tooltip (shown on hover)
     marker.bindTooltip(

--- a/web/src/lookup.html
+++ b/web/src/lookup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>gdns — DNS Lookup</title>
+  <title>dnsmon — DNS Lookup</title>
   <meta name="description" content="Perform a detailed single-resolver DNS lookup and see the full DNS response." />
   <link rel="stylesheet" href="/css/app.css" />
 </head>
@@ -15,11 +15,11 @@
       <div class="flex items-center justify-between h-14">
 
         <!-- Logo -->
-        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="gdns home">
+        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="dnsmon home">
           <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
           </svg>
-          <span>gdns</span>
+          <span>dnsmon</span>
         </a>
 
         <!-- Desktop links -->
@@ -264,12 +264,12 @@
       <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400 dark:text-slate-500">
         <div class="flex items-center gap-2">
           <svg class="w-5 h-5 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          <span class="font-medium text-slate-600 dark:text-slate-300">gdns</span>
+          <span class="font-medium text-slate-600 dark:text-slate-300">dnsmon</span>
           <span>&#8212; Self-hosted DNS propagation checker</span>
         </div>
         <div class="flex items-center gap-4">
           <a href="/about" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">About</a>
-          <a href="https://github.com/tomerklein/gdns" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/t0mer/dnsmon" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="/api-docs" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">API</a>
         </div>
       </div>

--- a/web/src/reverse.html
+++ b/web/src/reverse.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>gdns — Reverse DNS Lookup</title>
+  <title>dnsmon — Reverse DNS Lookup</title>
   <meta name="description" content="Reverse DNS (PTR) lookup across global resolvers. Find the hostname for any IPv4 or IPv6 address." />
   <link rel="stylesheet" href="/css/app.css" />
   <!-- Leaflet -->
@@ -23,11 +23,11 @@
       <div class="flex items-center justify-between h-14">
 
         <!-- Logo -->
-        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="gdns home">
+        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="dnsmon home">
           <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
           </svg>
-          <span>gdns</span>
+          <span>dnsmon</span>
         </a>
 
         <!-- Desktop links -->
@@ -326,12 +326,12 @@
       <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400 dark:text-slate-500">
         <div class="flex items-center gap-2">
           <svg class="w-5 h-5 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          <span class="font-medium text-slate-600 dark:text-slate-300">gdns</span>
+          <span class="font-medium text-slate-600 dark:text-slate-300">dnsmon</span>
           <span>&#8212; Self-hosted DNS propagation checker</span>
         </div>
         <div class="flex items-center gap-4">
           <a href="/about" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">About</a>
-          <a href="https://github.com/tomerklein/gdns" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/t0mer/dnsmon" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="/api-docs" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">API</a>
         </div>
       </div>

--- a/web/src/reverse.html
+++ b/web/src/reverse.html
@@ -190,7 +190,11 @@
               }">
               <div class="flex items-start justify-between gap-2">
                 <div class="flex items-center gap-2 min-w-0">
-                  <span class="text-xl flex-shrink-0" x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                  <span class="relative flex-shrink-0 group cursor-default">
+                    <span class="text-xl" x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                    <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
+                      x-text="countryName(result.resolver.country)"></span>
+                  </span>
                   <div class="min-w-0">
                     <div class="font-medium text-slate-900 dark:text-white text-sm truncate" x-text="result.resolver.name"></div>
                     <div class="text-xs text-slate-500 dark:text-slate-400 font-mono" x-text="result.resolver.ip"></div>
@@ -220,8 +224,14 @@
                   <div class="text-xs font-mono text-emerald-700 dark:text-emerald-400 truncate" x-text="ans.value" :title="ans.value"></div>
                 </template>
               </div>
-              <div class="mt-1 ml-9 text-xs text-slate-400 dark:text-slate-500"
-                x-text="[result.resolver.city, result.resolver.country].filter(Boolean).join(', ')"></div>
+              <div class="mt-1 ml-9 text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1">
+                <span class="relative group cursor-default">
+                  <span x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                  <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
+                    x-text="countryName(result.resolver.country)"></span>
+                </span>
+                <span x-text="result.resolver.city || ''"></span>
+              </div>
             </div>
           </template>
         </div>
@@ -245,7 +255,11 @@
                 <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/30 transition-colors animate-fade-in">
                   <!-- Flag -->
                   <td class="px-4 py-3">
-                    <span class="text-xl" x-text="countryFlag(result.resolver.country)" :title="result.resolver.country" aria-hidden="true"></span>
+                    <span class="relative inline-block group cursor-default">
+                      <span class="text-xl" x-text="countryFlag(result.resolver.country)" aria-hidden="true"></span>
+                      <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
+                        x-text="countryName(result.resolver.country)"></span>
+                    </span>
                   </td>
                   <!-- Resolver -->
                   <td class="px-4 py-3">
@@ -254,7 +268,7 @@
                   </td>
                   <!-- Location -->
                   <td class="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs">
-                    <span x-text="[result.resolver.city, result.resolver.country].filter(Boolean).join(', ')"></span>
+                    <span x-text="result.resolver.city || '—'"></span>
                   </td>
                   <!-- Status badge -->
                   <td class="px-4 py-3">


### PR DESCRIPTION
  ## Summary
  - Rename the project from `gdns` to `dnsmon` throughout (binary path `cmd/dnsmon`, module URLs, config keys `DNSMON_*`, Prometheus metric prefix `dnsmon_*`,
  docs, deploy manifests).
  - Replace raw two-letter ISO country codes in results with the country flag emoji; hovering a flag shows a tooltip bubble with the full country name
  (`Intl.DisplayNames`). Applies to the propagation and reverse-DNS views, both desktop table and mobile cards.

  ## Changes
  - 60 files changed, +403 / -360
  - Frontend: `web/src/index.html`, `web/src/reverse.html`, `web/src/js/app.js`
  - Backend rename: `internal/**`, `cmd/dnsmon/main.go`, config, docs, deploy

  ## Test plan
  - [ ] `go build ./cmd/dnsmon` succeeds
  - [ ] Run a propagation check — flags render, hover shows full country name
  - [ ] Reverse lookup view shows the same flag/tooltip behavior
  - [ ] Dark mode tooltip is legible