### PR TITLE
style: shrink result-list flags to text-base

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -294,7 +294,7 @@
                 <!-- Left: flag + resolver info -->
                 <div class="flex items-center gap-2 min-w-0">
                   <span class="relative flex-shrink-0 group cursor-default">
-                    <span class="fi text-xl rounded-sm ring-1 ring-black/5"
+                    <span class="fi text-base rounded-sm ring-1 ring-black/5"
                       :class="'fi-' + (result.resolver.country || 'xx').toLowerCase()" aria-hidden="true"></span>
                     <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
                       x-text="countryName(result.resolver.country)"></span>
@@ -380,7 +380,7 @@
                   <!-- Flag -->
                   <td class="px-4 py-3">
                     <span class="relative inline-block group cursor-default">
-                      <span class="fi text-xl rounded-sm ring-1 ring-black/5"
+                      <span class="fi text-base rounded-sm ring-1 ring-black/5"
                         :class="'fi-' + (result.resolver.country || 'xx').toLowerCase()" aria-hidden="true"></span>
                       <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
                         x-text="countryName(result.resolver.country)"></span>

--- a/web/src/reverse.html
+++ b/web/src/reverse.html
@@ -193,7 +193,7 @@
               <div class="flex items-start justify-between gap-2">
                 <div class="flex items-center gap-2 min-w-0">
                   <span class="relative flex-shrink-0 group cursor-default">
-                    <span class="fi text-xl rounded-sm ring-1 ring-black/5"
+                    <span class="fi text-base rounded-sm ring-1 ring-black/5"
                       :class="'fi-' + (result.resolver.country || 'xx').toLowerCase()" aria-hidden="true"></span>
                     <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
                       x-text="countryName(result.resolver.country)"></span>
@@ -260,7 +260,7 @@
                   <!-- Flag -->
                   <td class="px-4 py-3">
                     <span class="relative inline-block group cursor-default">
-                      <span class="fi text-xl rounded-sm ring-1 ring-black/5"
+                      <span class="fi text-base rounded-sm ring-1 ring-black/5"
                         :class="'fi-' + (result.resolver.country || 'xx').toLowerCase()" aria-hidden="true"></span>
                       <span class="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs rounded-md bg-slate-800 dark:bg-slate-700 text-white whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-lg"
                         x-text="countryName(result.resolver.country)"></span>


### PR DESCRIPTION
Reduce the country flag size in the propagation and reverse-DNS result lists from text-xl to text-base (~21x16px) so they sit better against the resolver name. The hover tooltip behaviour is unchanged — it was only appearing permanently due to a stale local Tailwind build; a normal `make ui`/Docker build emits the opacity-0/group-hover rules.