### PR TITLE
Add CLI flags: --port, --service (install/uninstall/start/stop/restart), and PORT env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ The goal: **deploy with one `docker compose up` and have a private whatsmydns in
 | Container            | Distroless static                                  | <20 MB image.                                                          |
 | Testing              | stdlib `testing` + `stretchr/testify`              | Unit + integration; DNS mocked with `miekg/dns` test server.            |
 | Linting              | `golangci-lint`                                    | Config in `.golangci.yml`.                                              |
+| Service mgmt         | `github.com/kardianos/service`                     | `--service install/uninstall` registers dnsmon as a Windows SCM / systemd / launchd service. Speaks the Windows Service Control Manager protocol so the binary runs correctly under SCM; hand-rolling this per-OS would be far more code. |
 
 **Do not introduce new dependencies without listing them here first and explaining the trade-off.**
 

--- a/cmd/dnsmon/main.go
+++ b/cmd/dnsmon/main.go
@@ -5,12 +5,15 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/kardianos/service"
 	"github.com/t0mer/dnsmon/internal/api"
 	"github.com/t0mer/dnsmon/internal/cache"
 	"github.com/t0mer/dnsmon/internal/checker"
@@ -18,8 +21,8 @@ import (
 	"github.com/t0mer/dnsmon/internal/dnsclient"
 	"github.com/t0mer/dnsmon/internal/resolvers"
 	"github.com/t0mer/dnsmon/internal/storage"
-	sqlitestore "github.com/t0mer/dnsmon/internal/storage/sqlite"
 	pgstore "github.com/t0mer/dnsmon/internal/storage/postgres"
+	sqlitestore "github.com/t0mer/dnsmon/internal/storage/sqlite"
 	"github.com/t0mer/dnsmon/internal/version"
 )
 
@@ -28,7 +31,9 @@ func main() {
 		cfgFile       = flag.String("config", "", "path to config file")
 		resolversFile = flag.String("resolvers-file", "", "path to extra resolvers JSON file")
 		listen        = flag.String("listen", "", "override listen address (e.g. :8080)")
+		port          = flag.Int("port", 0, "override server port (e.g. 8080)")
 		logLevel      = flag.String("log-level", "", "override log level (debug|info|warn|error)")
+		serviceAction = flag.String("service", "", "manage the system service: install|uninstall|start|stop|restart")
 	)
 	flag.Parse()
 
@@ -41,6 +46,9 @@ func main() {
 	if *listen != "" {
 		cfg.Server.Listen = *listen
 	}
+	if *port != 0 {
+		cfg.Server.Listen = applyPortOverride(cfg.Server.Listen, *port)
+	}
 	if *logLevel != "" {
 		cfg.Log.Level = *logLevel
 	}
@@ -50,8 +58,31 @@ func main() {
 
 	log := newLogger(cfg)
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
+	prog := &program{cfg: cfg, log: log}
+
+	svcConfig := &service.Config{
+		Name:        "dnsmon",
+		DisplayName: "dnsmon — DNS Propagation Checker",
+		Description: "Self-hosted DNS propagation checker (whatsmydns.net alternative).",
+		Arguments:   serviceArguments(*cfgFile, *resolversFile, *listen, *port, *logLevel),
+	}
+
+	svc, err := service.New(prog, svcConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create service: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Service management actions exit after running; they never start the server.
+	if *serviceAction != "" {
+		if err := service.Control(svc, *serviceAction); err != nil {
+			fmt.Fprintf(os.Stderr, "service %s failed: %v\nvalid actions: %s\n",
+				*serviceAction, err, strings.Join(service.ControlAction[:], ", "))
+			os.Exit(1)
+		}
+		fmt.Printf("service %q: %s ok\n", svcConfig.Name, *serviceAction)
+		return
+	}
 
 	info := version.BuildInfo()
 	log.Info("starting dnsmon",
@@ -60,69 +91,144 @@ func main() {
 		slog.String("listen", cfg.Server.Listen),
 	)
 
-	store, err := newStorage(ctx, cfg, log)
-	if err != nil {
-		log.Error("failed to initialise storage", slog.Any("error", err))
+	// Run blocks until the service is stopped (SIGINT/SIGTERM when interactive,
+	// or a stop request from the OS service manager), then calls Stop.
+	if err := svc.Run(); err != nil {
+		log.Error("service run error", slog.Any("error", err))
 		os.Exit(1)
 	}
-	defer store.Close()
+}
 
-	cacheStore, err := cache.New(cfg)
+// program implements service.Interface, wiring the HTTP server lifecycle to the
+// service manager (or to an interactive run).
+type program struct {
+	cfg *config.Config
+	log *slog.Logger
+
+	httpServer *http.Server
+	store      storage.Storage
+	cacheStore cache.Cache
+}
+
+// Start initialises dependencies and launches the HTTP server. It must not block.
+func (p *program) Start(service.Service) error {
+	ctx := context.Background()
+
+	store, err := newStorage(ctx, p.cfg, p.log)
 	if err != nil {
-		log.Error("failed to initialise cache", slog.Any("error", err))
-		os.Exit(1)
+		return fmt.Errorf("initialising storage: %w", err)
 	}
-	defer cacheStore.Close()
+	p.store = store
+
+	cacheStore, err := cache.New(p.cfg)
+	if err != nil {
+		return fmt.Errorf("initialising cache: %w", err)
+	}
+	p.cacheStore = cacheStore
 
 	builtin, err := resolvers.LoadBuiltin()
 	if err != nil {
-		log.Warn("failed to load builtin resolvers, continuing with empty list", slog.Any("error", err))
+		p.log.Warn("failed to load builtin resolvers, continuing with empty list", slog.Any("error", err))
 		builtin = nil
 	}
 
 	registry := resolvers.NewRegistry()
-	if err := registry.Reload(ctx, cfg, builtin); err != nil {
-		log.Error("failed to load resolvers", slog.Any("error", err))
-		os.Exit(1)
+	if err := registry.Reload(ctx, p.cfg, builtin); err != nil {
+		return fmt.Errorf("loading resolvers: %w", err)
 	}
-	log.Info("resolvers loaded", slog.Int("count", len(registry.All())))
+	p.log.Info("resolvers loaded", slog.Int("count", len(registry.All())))
 
-	dnsClient := dnsclient.New(cfg)
-	chkr := checker.New(dnsClient, registry, cacheStore, store, cfg)
+	dnsClient := dnsclient.New(p.cfg)
+	chkr := checker.New(dnsClient, registry, cacheStore, store, p.cfg)
+	srv := api.NewServer(chkr, registry, store, p.cfg, p.log)
 
-	srv := api.NewServer(chkr, registry, store, cfg, log)
-
-	httpServer := &http.Server{
-		Addr:         cfg.Server.Listen,
+	p.httpServer = &http.Server{
+		Addr:         p.cfg.Server.Listen,
 		Handler:      srv.Handler(),
-		ReadTimeout:  cfg.Server.ReadTimeout,
-		WriteTimeout: cfg.Server.WriteTimeout,
+		ReadTimeout:  p.cfg.Server.ReadTimeout,
+		WriteTimeout: p.cfg.Server.WriteTimeout,
 	}
 
-	serverErr := make(chan error, 1)
-	go func() {
-		log.Info("http server listening", slog.String("addr", cfg.Server.Listen))
-		serverErr <- httpServer.ListenAndServe()
-	}()
+	go p.run()
+	return nil
+}
 
-	select {
-	case <-ctx.Done():
-		log.Info("shutting down")
-	case err := <-serverErr:
-		if err != nil && err != http.ErrServerClosed {
-			log.Error("server error", slog.Any("error", err))
+func (p *program) run() {
+	p.log.Info("http server listening", slog.String("addr", p.cfg.Server.Listen))
+	if err := p.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		p.log.Error("server error", slog.Any("error", err))
+		// When running interactively a fatal bind error should fail the process;
+		// under a service manager the manager decides on restart policy.
+		if service.Interactive() {
 			os.Exit(1)
 		}
 	}
+}
 
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer shutdownCancel()
+// Stop gracefully shuts down the HTTP server and releases resources.
+func (p *program) Stop(service.Service) error {
+	p.log.Info("shutting down")
 
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		log.Error("shutdown error", slog.Any("error", err))
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if p.httpServer != nil {
+		if err := p.httpServer.Shutdown(shutdownCtx); err != nil {
+			p.log.Error("shutdown error", slog.Any("error", err))
+		}
+	}
+	if p.store != nil {
+		p.store.Close()
+	}
+	if p.cacheStore != nil {
+		p.cacheStore.Close()
 	}
 
-	log.Info("shutdown complete")
+	p.log.Info("shutdown complete")
+	return nil
+}
+
+// serviceArguments reconstructs the flags the installed service should run with.
+// File paths are made absolute because the service runs from a different working
+// directory than the install command.
+func serviceArguments(cfgFile, resolversFile, listen string, port int, logLevel string) []string {
+	var args []string
+	if cfgFile != "" {
+		args = append(args, "--config", absOrSelf(cfgFile))
+	}
+	if resolversFile != "" {
+		args = append(args, "--resolvers-file", absOrSelf(resolversFile))
+	}
+	if listen != "" {
+		args = append(args, "--listen", listen)
+	}
+	if port != 0 {
+		args = append(args, "--port", strconv.Itoa(port))
+	}
+	if logLevel != "" {
+		args = append(args, "--log-level", logLevel)
+	}
+	return args
+}
+
+func absOrSelf(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+	return path
+}
+
+// applyPortOverride returns listen with its port replaced by port, preserving any
+// host portion. A non-positive port leaves listen unchanged.
+func applyPortOverride(listen string, port int) string {
+	if port <= 0 {
+		return listen
+	}
+	host := ""
+	if h, _, err := net.SplitHostPort(listen); err == nil {
+		host = h
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func newLogger(cfg *config.Config) *slog.Logger {

--- a/cmd/dnsmon/main.go
+++ b/cmd/dnsmon/main.go
@@ -43,12 +43,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *listen != "" {
-		cfg.Server.Listen = *listen
+	listenAddr, err := resolveListen(cfg.Server.Listen, *listen, *port, os.Getenv("PORT"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
 	}
-	if *port != 0 {
-		cfg.Server.Listen = applyPortOverride(cfg.Server.Listen, *port)
-	}
+	cfg.Server.Listen = listenAddr
+
 	if *logLevel != "" {
 		cfg.Log.Level = *logLevel
 	}
@@ -216,6 +217,27 @@ func absOrSelf(path string) string {
 		return abs
 	}
 	return path
+}
+
+// resolveListen computes the final listen address from the configured value, the
+// PORT environment variable (Docker convention), and the --listen/--port flags,
+// in increasing order of precedence: config < PORT env < --listen < --port.
+func resolveListen(configured, listenFlag string, portFlag int, portEnv string) (string, error) {
+	listen := configured
+	if portEnv != "" {
+		p, err := strconv.Atoi(portEnv)
+		if err != nil || p <= 0 {
+			return "", fmt.Errorf("invalid PORT environment value %q: must be a positive integer", portEnv)
+		}
+		listen = applyPortOverride(listen, p)
+	}
+	if listenFlag != "" {
+		listen = listenFlag
+	}
+	if portFlag != 0 {
+		listen = applyPortOverride(listen, portFlag)
+	}
+	return listen, nil
 }
 
 // applyPortOverride returns listen with its port replaced by port, preserving any

--- a/cmd/dnsmon/main_test.go
+++ b/cmd/dnsmon/main_test.go
@@ -26,6 +26,47 @@ func TestApplyPortOverride(t *testing.T) {
 	}
 }
 
+func TestResolveListen(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		listenFlag string
+		portFlag   int
+		portEnv    string
+		want       string
+		wantErr    bool
+	}{
+		{"nothing set keeps config", ":8080", "", 0, "", ":8080", false},
+		{"PORT env overrides config port", ":8080", "", 0, "9000", ":9000", false},
+		{"PORT env preserves host", "127.0.0.1:8080", "", 0, "9000", "127.0.0.1:9000", false},
+		{"--listen overrides PORT env", ":8080", "0.0.0.0:7000", 0, "9000", "0.0.0.0:7000", false},
+		{"--port overrides everything", ":8080", "0.0.0.0:7000", 6000, "9000", "0.0.0.0:6000", false},
+		{"--port overrides PORT env", ":8080", "", 6000, "9000", ":6000", false},
+		{"invalid PORT errors", ":8080", "", 0, "abc", "", true},
+		{"zero PORT errors", ":8080", "", 0, "0", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveListen(tt.configured, tt.listenFlag, tt.portFlag, tt.portEnv)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveListen(%q,%q,%d,%q) expected error, got %q",
+						tt.configured, tt.listenFlag, tt.portFlag, tt.portEnv, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveListen returned unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveListen(%q,%q,%d,%q) = %q, want %q",
+					tt.configured, tt.listenFlag, tt.portFlag, tt.portEnv, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestServiceArguments(t *testing.T) {
 	got := serviceArguments("", "", ":8080", 9000, "debug")
 	want := []string{"--listen", ":8080", "--port", "9000", "--log-level", "debug"}

--- a/cmd/dnsmon/main_test.go
+++ b/cmd/dnsmon/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestApplyPortOverride(t *testing.T) {
+	tests := []struct {
+		name   string
+		listen string
+		port   int
+		want   string
+	}{
+		{"port-only listen", ":8080", 9000, ":9000"},
+		{"host and port listen", "0.0.0.0:8080", 9000, "0.0.0.0:9000"},
+		{"named host listen", "localhost:8080", 1234, "localhost:1234"},
+		{"empty listen", "", 8080, ":8080"},
+		{"zero port is no-op", ":8080", 0, ":8080"},
+		{"negative port is no-op", "0.0.0.0:8080", -1, "0.0.0.0:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := applyPortOverride(tt.listen, tt.port); got != tt.want {
+				t.Errorf("applyPortOverride(%q, %d) = %q, want %q", tt.listen, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceArguments(t *testing.T) {
+	got := serviceArguments("", "", ":8080", 9000, "debug")
+	want := []string{"--listen", ":8080", "--port", "9000", "--log-level", "debug"}
+	if len(got) != len(want) {
+		t.Fatalf("serviceArguments length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("serviceArguments[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/deploy/docker-compose.sqlite.yml
+++ b/deploy/docker-compose.sqlite.yml
@@ -8,6 +8,9 @@ services:
     ports:
       - "8080:8080"
     environment:
+      # PORT sets the server listen port (Docker/PaaS convention). Equivalent
+      # to DNSMON_SERVER_LISTEN=":8080" but simpler for container platforms.
+      PORT: "8080"
       DNSMON_STORAGE_DRIVER: "sqlite"
       DNSMON_STORAGE_DSN: "file:/data/dnsmon.db?cache=shared&_fk=1"
       DNSMON_CACHE_DRIVER: "memory"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,6 +6,42 @@ Pass a config file path with `--config /path/to/config.yaml`.
 
 ---
 
+## Command-Line Flags
+
+Flags override the config file and environment for the current run.
+
+| Flag | Description |
+|---|---|
+| `--config` | Path to a YAML config file. |
+| `--listen` | Override the full listen address, e.g. `:8080` or `0.0.0.0:9090`. |
+| `--port` | Override only the port, preserving any host in `server.listen`. Example: `--port 9090`. Takes effect after `--listen` if both are given. |
+| `--log-level` | Override the log level (`debug`, `info`, `warn`, `error`). |
+| `--resolvers-file` | Path to an extra resolvers JSON/YAML file. |
+| `--service` | Manage dnsmon as a system service: `install`, `uninstall`, `start`, `stop`, or `restart`. |
+
+### Running as a system service
+
+`--service` registers dnsmon with the host service manager (Windows Service
+Control Manager, Linux systemd, or macOS launchd):
+
+```bash
+# Install (run with the flags the service should use; paths are made absolute)
+dnsmon --port 8080 --config /etc/dnsmon/config.yaml --service install
+
+# Then control it through the OS, or via dnsmon:
+dnsmon --service start
+dnsmon --service stop
+dnsmon --service uninstall
+```
+
+On Linux this requires root (it writes `/etc/systemd/system/dnsmon.service`);
+on Windows run the command from an elevated prompt. Any `--config`,
+`--resolvers-file`, `--listen`, `--port`, and `--log-level` flags passed
+alongside `--service install` are baked into the service definition so the
+service starts with the same settings.
+
+---
+
 ## server
 
 HTTP server settings.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,6 +19,19 @@ Flags override the config file and environment for the current run.
 | `--resolvers-file` | Path to an extra resolvers JSON/YAML file. |
 | `--service` | Manage dnsmon as a system service: `install`, `uninstall`, `start`, `stop`, or `restart`. |
 
+### The `PORT` environment variable
+
+For container platforms (Docker, Cloud Run, Heroku, etc.) the bare `PORT`
+environment variable sets the server port without needing the `DNSMON_` prefix:
+
+```bash
+PORT=9090 dnsmon          # listens on :9090
+```
+
+`PORT` overrides the port in `server.listen` (preserving any host). Precedence,
+lowest to highest: `server.listen` (config / `DNSMON_SERVER_LISTEN`) < `PORT`
+env < `--listen` flag < `--port` flag.
+
 ### Running as a system service
 
 `--service` registers dnsmon with the host service manager (Windows Service

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jung-kurt/gofpdf v1.16.2
+	github.com/kardianos/service v1.2.4
 	github.com/miekg/dns v1.1.62
 	github.com/oschwald/geoip2-golang v1.11.0
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5PtRc=
 github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
+github.com/kardianos/service v1.2.4 h1:XNlGtZOYNx2u91urOdg/Kfmc+gfmuIo1Dd3rEi2OgBk=
+github.com/kardianos/service v1.2.4/go.mod h1:E4V9ufUuY82F7Ztlu1eN9VXWIQxg8NoLQlmFe0MtrXc=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
  ## Summary
  - Add `--port` to override just the server port (preserving any host in `server.listen`), e.g. `dnsmon --port 9090`.
  - Add `--service install|uninstall|start|stop|restart` to register/manage dnsmon as a system service via `github.com/kardianos/service` (Windows SCM, Linux systemd, macOS launchd). The server
  lifecycle is refactored into a `service.Interface` (`Start`/`Stop`); kardianos handles signals when run interactively.
  - Add support for the bare `PORT` environment variable (Docker/Cloud Run/Heroku convention) to set the server port without the `DNSMON_` prefix.

  ## Details
  **Listen-address precedence** (lowest → highest):
  `server.listen` (config / `DNSMON_SERVER_LISTEN`) < `PORT` env < `--listen` flag < `--port` flag. An invalid `PORT` value fails fast with a clear message.

  **Service install** bakes the flags passed alongside it (`--config`, `--resolvers-file`, `--listen`, `--port`, `--log-level`) into the service definition, with file paths made absolute since the
  service runs from a different working directory.

  **New dependency:** `github.com/kardianos/service` — chosen because a correct Windows service must speak the Service Control Manager protocol; hand-rolling that per-OS would be far more code.
  Documented in CLAUDE.md §2.

  ## Changes
  - `cmd/dnsmon/main.go` — flags, `resolveListen`/`applyPortOverride`/`serviceArguments` helpers, `program` implementing `service.Interface`.
  - `cmd/dnsmon/main_test.go` — unit tests for port-override, listen resolution/precedence, and service-argument forwarding.
  - `docs/CONFIGURATION.md` — Command-Line Flags section, `PORT` env var, running as a service.
  - `deploy/docker-compose.sqlite.yml` — `PORT` example.
  - `CLAUDE.md` — kardianos/service in the dependency table.
  - `go.mod` / `go.sum`.

  ## Test plan
  - [x] `go build ./...`, `go vet`, `go test ./cmd/dnsmon/` pass
  - [x] `--port 9099` → server listens on :9099 (200)
  - [x] `PORT=9077` → server listens on :9077 (200)
  - [x] `--port` overrides `PORT` env (flag wins)
  - [x] invalid `PORT` → clear error, non-zero exit
  - [x] `--service` rejects unknown actions and lists valid ones; `restart` dispatches through `service.Control`
  - [ ] Real `--service install` → `start` → `uninstall` on a target host (Linux systemd / Windows SCM) — not run in-session (host-mutating)