### PR TITLE
Add Settings page: notifications, optional auth, API tokens, resolver & scheduler management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/crypto v0.49.0
 	modernc.org/sqlite v1.33.1
 )
 
@@ -58,7 +59,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a // indirect
 	golang.org/x/mod v0.33.0 // indirect

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -20,6 +20,17 @@ components:
       bearerFormat: API key
 
   schemas:
+    SessionStatus:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Whether UI authentication is enabled.
+        authenticated:
+          type: boolean
+        username:
+          type: string
+
     NotificationChannel:
       type: object
       properties:
@@ -627,6 +638,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/login:
+    post:
+      summary: Sign in to the UI
+      description: Verifies the admin credentials (when auth is enabled) and sets an HttpOnly session cookie.
+      operationId: login
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, password]
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Authenticated; session cookie set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStatus'
+        '401':
+          description: Invalid username or password
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/logout:
+    post:
+      summary: Sign out
+      operationId: logout
+      tags: [Auth]
+      responses:
+        '200':
+          description: Session cookie cleared
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStatus'
+
+  /auth/session:
+    get:
+      summary: Current session status
+      operationId: authSession
+      tags: [Auth]
+      responses:
+        '200':
+          description: Whether auth is enabled and whether the caller is authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStatus'
 
   /settings:
     get:

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -20,6 +20,116 @@ components:
       bearerFormat: API key
 
   schemas:
+    NotificationChannel:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [shoutrrr, greenapi, gowa]
+        name:
+          type: string
+        enabled:
+          type: boolean
+        config:
+          type: object
+          additionalProperties:
+            type: string
+
+    SettingsView:
+      type: object
+      properties:
+        auth:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            username:
+              type: string
+            password_set:
+              type: boolean
+        notifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationChannel'
+        disabled_resolvers:
+          type: array
+          items:
+            type: string
+
+    SettingsUpdate:
+      type: object
+      properties:
+        auth:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            username:
+              type: string
+            password:
+              type: string
+              description: Set to change the admin password; omit or leave empty to keep the current one.
+        notifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationChannel'
+        disabled_resolvers:
+          type: array
+          items:
+            type: string
+
+    APIToken:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        prefix:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    ScheduleInput:
+      type: object
+      required: [name, domain, type]
+      properties:
+        name:
+          type: string
+        domain:
+          type: string
+        type:
+          type: string
+        resolvers:
+          type: array
+          items:
+            type: string
+        interval_sec:
+          type: integer
+        enabled:
+          type: boolean
+
+    Schedule:
+      allOf:
+        - $ref: '#/components/schemas/ScheduleInput'
+        - type: object
+          properties:
+            id:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+
     Answer:
       type: object
       properties:
@@ -517,3 +627,187 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /settings:
+    get:
+      summary: Get application settings
+      description: Returns settings with secrets redacted (the admin password is never returned; only whether one is set).
+      operationId: getSettings
+      tags: [Settings]
+      responses:
+        '200':
+          description: Current settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsView'
+    put:
+      summary: Update application settings
+      description: Updates auth (optional UI login), notification channels, and the set of disabled resolver IDs. Provide `auth.password` only to change it.
+      operationId: updateSettings
+      tags: [Settings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SettingsUpdate'
+      responses:
+        '200':
+          description: Updated settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsView'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /settings/notifications/test:
+    post:
+      summary: Send a test notification (not implemented yet)
+      operationId: testNotification
+      tags: [Settings]
+      responses:
+        '501':
+          description: Not implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /settings/tokens:
+    get:
+      summary: List API tokens
+      operationId: listTokens
+      tags: [Settings]
+      responses:
+        '200':
+          description: API tokens (without secrets)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/APIToken'
+    post:
+      summary: Create an API token
+      description: Returns the raw token once; only its hash is stored.
+      operationId: createToken
+      tags: [Settings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created token (raw secret included once)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIToken'
+                  - type: object
+                    properties:
+                      token:
+                        type: string
+
+  /settings/tokens/{id}:
+    delete:
+      summary: Revoke an API token
+      operationId: deleteToken
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+
+  /settings/schedules:
+    get:
+      summary: List monitoring schedules
+      operationId: listSchedules
+      tags: [Settings]
+      responses:
+        '200':
+          description: Schedules
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Schedule'
+    post:
+      summary: Create a monitoring schedule
+      operationId: createSchedule
+      tags: [Settings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleInput'
+      responses:
+        '201':
+          description: Created schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+
+  /settings/schedules/{id}:
+    put:
+      summary: Update a monitoring schedule
+      operationId: updateSchedule
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleInput'
+      responses:
+        '200':
+          description: Updated schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+        '404':
+          description: Not found
+    delete:
+      summary: Delete a monitoring schedule
+      operationId: deleteSchedule
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -6,6 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
 )
 
 type contextKey string
@@ -68,6 +72,46 @@ func Recovery(log *slog.Logger) func(http.Handler) http.Handler {
 					_, _ = w.Write([]byte(`{"error":{"code":"INTERNAL_ERROR","message":"Internal server error."}}`))
 				}
 			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireAuth gates access when UI authentication is enabled in settings. When
+// disabled, requests pass through untouched. When enabled, a valid session
+// cookie is required; unauthenticated API requests get 401 (apiMode=true) while
+// unauthenticated page requests are redirected to /login (apiMode=false).
+func RequireAuth(store storage.Storage, apiMode bool) func(http.Handler) http.Handler {
+	deny := func(w http.ResponseWriter, r *http.Request) {
+		if apiMode {
+			apierr.WriteError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "Authentication required.", nil)
+			return
+		}
+		http.Redirect(w, r, "/login", http.StatusFound)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s, err := store.GetSettings(r.Context())
+			if err != nil {
+				deny(w, r)
+				return
+			}
+			if !s.Auth.Enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			c, err := r.Cookie(settings.SessionCookie)
+			if err != nil {
+				deny(w, r)
+				return
+			}
+			name, ok := settings.ParseSession(s.SessionSecret, c.Value)
+			if !ok || name != s.Auth.Username {
+				deny(w, r)
+				return
+			}
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -84,8 +84,12 @@ func (s *Server) routes() {
 		r.URL.Path = "/about.html"
 		fileServer.ServeHTTP(w, r)
 	})
-	r.Get("/settings", func(w http.ResponseWriter, r *http.Request) {
+	r.With(RequireAuth(s.storage, false)).Get("/settings", func(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = "/settings.html"
+		fileServer.ServeHTTP(w, r)
+	})
+	r.Get("/login", func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = "/login.html"
 		fileServer.ServeHTTP(w, r)
 	})
 	r.Get("/api-docs", func(w http.ResponseWriter, r *http.Request) {
@@ -120,17 +124,26 @@ func (s *Server) routes() {
 		r.Get("/history", v1.ListHistory(s.storage))
 		r.Delete("/history/{id}", v1.DeleteHistory(s.storage))
 
-		// Settings
-		r.Get("/settings", v1.GetSettings(s.storage))
-		r.Put("/settings", v1.UpdateSettings(s.storage))
-		r.Post("/settings/notifications/test", v1.TestNotification())
-		r.Get("/settings/tokens", v1.ListTokens(s.storage))
-		r.Post("/settings/tokens", v1.CreateToken(s.storage))
-		r.Delete("/settings/tokens/{id}", v1.DeleteToken(s.storage))
-		r.Get("/settings/schedules", v1.ListSchedules(s.storage))
-		r.Post("/settings/schedules", v1.CreateSchedule(s.storage))
-		r.Put("/settings/schedules/{id}", v1.UpdateSchedule(s.storage))
-		r.Delete("/settings/schedules/{id}", v1.DeleteSchedule(s.storage))
+		// Authentication (public so the login form can reach it)
+		r.Post("/auth/login", v1.Login(s.storage))
+		r.Post("/auth/logout", v1.Logout())
+		r.Get("/auth/session", v1.Session(s.storage))
+
+		// Settings — gated by UI auth when enabled.
+		r.Group(func(r chi.Router) {
+			r.Use(RequireAuth(s.storage, true))
+
+			r.Get("/settings", v1.GetSettings(s.storage))
+			r.Put("/settings", v1.UpdateSettings(s.storage))
+			r.Post("/settings/notifications/test", v1.TestNotification())
+			r.Get("/settings/tokens", v1.ListTokens(s.storage))
+			r.Post("/settings/tokens", v1.CreateToken(s.storage))
+			r.Delete("/settings/tokens/{id}", v1.DeleteToken(s.storage))
+			r.Get("/settings/schedules", v1.ListSchedules(s.storage))
+			r.Post("/settings/schedules", v1.CreateSchedule(s.storage))
+			r.Put("/settings/schedules/{id}", v1.UpdateSchedule(s.storage))
+			r.Delete("/settings/schedules/{id}", v1.DeleteSchedule(s.storage))
+		})
 	})
 
 	// Prometheus metrics

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -84,6 +84,10 @@ func (s *Server) routes() {
 		r.URL.Path = "/about.html"
 		fileServer.ServeHTTP(w, r)
 	})
+	r.Get("/settings", func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = "/settings.html"
+		fileServer.ServeHTTP(w, r)
+	})
 	r.Get("/api-docs", func(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = "/api-docs.html"
 		fileServer.ServeHTTP(w, r)
@@ -115,6 +119,18 @@ func (s *Server) routes() {
 
 		r.Get("/history", v1.ListHistory(s.storage))
 		r.Delete("/history/{id}", v1.DeleteHistory(s.storage))
+
+		// Settings
+		r.Get("/settings", v1.GetSettings(s.storage))
+		r.Put("/settings", v1.UpdateSettings(s.storage))
+		r.Post("/settings/notifications/test", v1.TestNotification())
+		r.Get("/settings/tokens", v1.ListTokens(s.storage))
+		r.Post("/settings/tokens", v1.CreateToken(s.storage))
+		r.Delete("/settings/tokens/{id}", v1.DeleteToken(s.storage))
+		r.Get("/settings/schedules", v1.ListSchedules(s.storage))
+		r.Post("/settings/schedules", v1.CreateSchedule(s.storage))
+		r.Put("/settings/schedules/{id}", v1.UpdateSchedule(s.storage))
+		r.Delete("/settings/schedules/{id}", v1.DeleteSchedule(s.storage))
 	})
 
 	// Prometheus metrics

--- a/internal/api/v1/auth.go
+++ b/internal/api/v1/auth.go
@@ -1,0 +1,114 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+const sessionTTL = 7 * 24 * time.Hour
+
+type loginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type sessionResponse struct {
+	Enabled       bool   `json:"enabled"`
+	Authenticated bool   `json:"authenticated"`
+	Username      string `json:"username,omitempty"`
+}
+
+// Login handles POST /api/v1/auth/login. On success it sets an HttpOnly
+// session cookie.
+func Login(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req loginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, "Invalid request body.", nil)
+			return
+		}
+
+		s, err := store.GetSettings(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to load settings.", nil)
+			return
+		}
+		if !s.Auth.Enabled {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, "Authentication is not enabled.", nil)
+			return
+		}
+
+		if req.Username != s.Auth.Username || !settings.VerifySecret(req.Password, s.Auth.PasswordHash) {
+			apierr.WriteError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid username or password.", nil)
+			return
+		}
+
+		// Lazily generate and persist a signing secret on first login.
+		if s.SessionSecret == "" {
+			secret, err := settings.GenerateToken()
+			if err != nil {
+				apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to start session.", nil)
+				return
+			}
+			s.SessionSecret = secret
+			if err := store.SaveSettings(r.Context(), s); err != nil {
+				apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to persist session secret.", nil)
+				return
+			}
+		}
+
+		token := settings.SignSession(s.SessionSecret, s.Auth.Username, sessionTTL)
+		http.SetCookie(w, &http.Cookie{
+			Name:     settings.SessionCookie,
+			Value:    token,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Expires:  time.Now().Add(sessionTTL),
+		})
+		apierr.WriteJSON(w, http.StatusOK, sessionResponse{Enabled: true, Authenticated: true, Username: s.Auth.Username})
+	}
+}
+
+// Logout handles POST /api/v1/auth/logout, clearing the session cookie.
+func Logout() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     settings.SessionCookie,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   -1,
+			Expires:  time.Unix(0, 0),
+		})
+		apierr.WriteJSON(w, http.StatusOK, sessionResponse{Authenticated: false})
+	}
+}
+
+// Session handles GET /api/v1/auth/session, reporting whether auth is enabled
+// and whether the caller is currently authenticated.
+func Session(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s, err := store.GetSettings(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to load settings.", nil)
+			return
+		}
+		resp := sessionResponse{Enabled: s.Auth.Enabled}
+		if s.Auth.Enabled {
+			if c, err := r.Cookie(settings.SessionCookie); err == nil {
+				if name, ok := settings.ParseSession(s.SessionSecret, c.Value); ok && name == s.Auth.Username {
+					resp.Authenticated = true
+					resp.Username = name
+				}
+			}
+		}
+		apierr.WriteJSON(w, http.StatusOK, resp)
+	}
+}

--- a/internal/api/v1/settings.go
+++ b/internal/api/v1/settings.go
@@ -1,0 +1,364 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+// settingsView is the redacted settings representation returned to clients.
+// The admin password hash is never exposed; only whether one is set.
+type settingsView struct {
+	Auth struct {
+		Enabled     bool   `json:"enabled"`
+		Username    string `json:"username"`
+		PasswordSet bool   `json:"password_set"`
+	} `json:"auth"`
+	Notifications     []settings.NotificationChannel `json:"notifications"`
+	DisabledResolvers []string                       `json:"disabled_resolvers"`
+}
+
+func toView(s *settings.Settings) settingsView {
+	var v settingsView
+	v.Auth.Enabled = s.Auth.Enabled
+	v.Auth.Username = s.Auth.Username
+	v.Auth.PasswordSet = s.Auth.PasswordHash != ""
+	v.Notifications = s.Notifications
+	if v.Notifications == nil {
+		v.Notifications = []settings.NotificationChannel{}
+	}
+	v.DisabledResolvers = s.DisabledResolvers
+	if v.DisabledResolvers == nil {
+		v.DisabledResolvers = []string{}
+	}
+	return v
+}
+
+// GetSettings handles GET /api/v1/settings.
+func GetSettings(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s, err := store.GetSettings(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to load settings.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusOK, toView(s))
+	}
+}
+
+type updateSettingsRequest struct {
+	Auth struct {
+		Enabled  bool   `json:"enabled"`
+		Username string `json:"username"`
+		Password string `json:"password"` // optional; replaces the stored password when non-empty
+	} `json:"auth"`
+	Notifications     []settings.NotificationChannel `json:"notifications"`
+	DisabledResolvers []string                       `json:"disabled_resolvers"`
+}
+
+// UpdateSettings handles PUT /api/v1/settings.
+func UpdateSettings(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req updateSettingsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				"Invalid request body.", nil)
+			return
+		}
+
+		current, err := store.GetSettings(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to load settings.", nil)
+			return
+		}
+
+		current.Auth.Enabled = req.Auth.Enabled
+		current.Auth.Username = req.Auth.Username
+		if req.Auth.Password != "" {
+			hash, err := settings.HashSecret(req.Auth.Password)
+			if err != nil {
+				apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+					"Failed to hash password.", nil)
+				return
+			}
+			current.Auth.PasswordHash = hash
+		}
+		if current.Auth.Enabled && (current.Auth.Username == "" || current.Auth.PasswordHash == "") {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				"A username and password are required to enable authentication.", nil)
+			return
+		}
+
+		// Ensure every notification channel has a stable ID.
+		channels := req.Notifications
+		if channels == nil {
+			channels = []settings.NotificationChannel{}
+		}
+		for i := range channels {
+			if channels[i].ID == "" {
+				channels[i].ID = settings.NewID()
+			}
+		}
+		current.Notifications = channels
+
+		if req.DisabledResolvers == nil {
+			current.DisabledResolvers = []string{}
+		} else {
+			current.DisabledResolvers = req.DisabledResolvers
+		}
+
+		if err := store.SaveSettings(r.Context(), current); err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to save settings.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusOK, toView(current))
+	}
+}
+
+// ListTokens handles GET /api/v1/settings/tokens.
+func ListTokens(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tokens, err := store.ListAPITokens(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to list API tokens.", nil)
+			return
+		}
+		if tokens == nil {
+			tokens = []*settings.APIToken{}
+		}
+		apierr.WriteJSON(w, http.StatusOK, tokens)
+	}
+}
+
+type createTokenRequest struct {
+	Name string `json:"name" validate:"required"`
+}
+
+type createTokenResponse struct {
+	*settings.APIToken
+	Token string `json:"token"` // raw secret, shown only once
+}
+
+// CreateToken handles POST /api/v1/settings/tokens.
+func CreateToken(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req createTokenRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				"Invalid request body.", nil)
+			return
+		}
+		if err := validate.Struct(req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				err.Error(), nil)
+			return
+		}
+
+		raw, err := settings.GenerateToken()
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to generate token.", nil)
+			return
+		}
+		hash, err := settings.HashSecret(raw)
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to hash token.", nil)
+			return
+		}
+
+		tok := &settings.APIToken{
+			ID:        settings.NewID(),
+			Name:      req.Name,
+			Hash:      hash,
+			Prefix:    raw[:8],
+			CreatedAt: time.Now().UTC(),
+		}
+		if err := store.CreateAPIToken(r.Context(), tok); err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to create token.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusCreated, createTokenResponse{APIToken: tok, Token: raw})
+	}
+}
+
+// DeleteToken handles DELETE /api/v1/settings/tokens/{id}.
+func DeleteToken(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := store.DeleteAPIToken(r.Context(), id); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				apierr.WriteError(w, r, http.StatusNotFound, apierr.ErrCodeNotFound, "Token not found.", nil)
+				return
+			}
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to delete token.", nil)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ListSchedules handles GET /api/v1/settings/schedules.
+func ListSchedules(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		list, err := store.ListSchedules(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to list schedules.", nil)
+			return
+		}
+		if list == nil {
+			list = []*settings.Schedule{}
+		}
+		apierr.WriteJSON(w, http.StatusOK, list)
+	}
+}
+
+type scheduleRequest struct {
+	Name        string   `json:"name" validate:"required"`
+	Domain      string   `json:"domain" validate:"required"`
+	Type        string   `json:"type" validate:"required"`
+	Resolvers   []string `json:"resolvers"`
+	IntervalSec int      `json:"interval_sec"`
+	Enabled     bool     `json:"enabled"`
+}
+
+func (req scheduleRequest) validate(w http.ResponseWriter, r *http.Request) bool {
+	if err := validate.Struct(req); err != nil {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, err.Error(), nil)
+		return false
+	}
+	if !domainRE.MatchString(req.Domain) {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidDomain, "Invalid domain name.", nil)
+		return false
+	}
+	return true
+}
+
+// CreateSchedule handles POST /api/v1/settings/schedules.
+func CreateSchedule(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req scheduleRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				"Invalid request body.", nil)
+			return
+		}
+		if !req.validate(w, r) {
+			return
+		}
+
+		now := time.Now().UTC()
+		sc := &settings.Schedule{
+			ID:          settings.NewID(),
+			Name:        req.Name,
+			Domain:      req.Domain,
+			Type:        req.Type,
+			Resolvers:   req.Resolvers,
+			IntervalSec: req.IntervalSec,
+			Enabled:     req.Enabled,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := store.SaveSchedule(r.Context(), sc); err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to create schedule.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusCreated, sc)
+	}
+}
+
+// UpdateSchedule handles PUT /api/v1/settings/schedules/{id}.
+func UpdateSchedule(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var req scheduleRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				"Invalid request body.", nil)
+			return
+		}
+		if !req.validate(w, r) {
+			return
+		}
+
+		existing, err := findSchedule(store, r, id)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				apierr.WriteError(w, r, http.StatusNotFound, apierr.ErrCodeNotFound, "Schedule not found.", nil)
+				return
+			}
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to load schedule.", nil)
+			return
+		}
+
+		existing.Name = req.Name
+		existing.Domain = req.Domain
+		existing.Type = req.Type
+		existing.Resolvers = req.Resolvers
+		existing.IntervalSec = req.IntervalSec
+		existing.Enabled = req.Enabled
+		existing.UpdatedAt = time.Now().UTC()
+
+		if err := store.SaveSchedule(r.Context(), existing); err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to update schedule.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusOK, existing)
+	}
+}
+
+// DeleteSchedule handles DELETE /api/v1/settings/schedules/{id}.
+func DeleteSchedule(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := store.DeleteSchedule(r.Context(), id); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				apierr.WriteError(w, r, http.StatusNotFound, apierr.ErrCodeNotFound, "Schedule not found.", nil)
+				return
+			}
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
+				"Failed to delete schedule.", nil)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func findSchedule(store storage.Storage, r *http.Request, id string) (*settings.Schedule, error) {
+	list, err := store.ListSchedules(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	for _, sc := range list {
+		if sc.ID == id {
+			return sc, nil
+		}
+	}
+	return nil, storage.ErrNotFound
+}
+
+// TestNotification handles POST /api/v1/settings/notifications/test.
+// Sending is implemented in a later change; this is a stub.
+func TestNotification() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		apierr.WriteError(w, r, http.StatusNotImplemented, "NOT_IMPLEMENTED",
+			"Notification delivery is not implemented yet.", nil)
+	}
+}

--- a/internal/api/v1/settings_test.go
+++ b/internal/api/v1/settings_test.go
@@ -1,0 +1,131 @@
+package v1_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "github.com/t0mer/dnsmon/internal/api/v1"
+	sqlitestore "github.com/t0mer/dnsmon/internal/storage/sqlite"
+)
+
+func newSettingsStore(t *testing.T) *sqlitestore.Store {
+	t.Helper()
+	s, err := sqlitestore.New(context.Background(), "file:"+t.TempDir()+"/settings.db?_fk=1")
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestGetSettings_Defaults(t *testing.T) {
+	store := newSettingsStore(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rr := httptest.NewRecorder()
+
+	v1.GetSettings(store).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	auth := body["auth"].(map[string]any)
+	assert.Equal(t, false, auth["enabled"])
+	assert.Equal(t, false, auth["password_set"])
+}
+
+func TestUpdateSettings_EnableAuthAndRedact(t *testing.T) {
+	store := newSettingsStore(t)
+
+	body := `{"auth":{"enabled":true,"username":"admin","password":"hunter2"},"notifications":[{"type":"shoutrrr","name":"ops","enabled":true,"config":{"url":"slack://x"}}],"disabled_resolvers":["google-us"]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	v1.UpdateSettings(store).ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Re-read; password hash must never be exposed, but password_set is true.
+	rr = httptest.NewRecorder()
+	v1.GetSettings(store).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "password_hash")
+	assert.NotContains(t, rr.Body.String(), "argon2")
+
+	var body2 map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body2))
+	auth := body2["auth"].(map[string]any)
+	assert.Equal(t, true, auth["enabled"])
+	assert.Equal(t, "admin", auth["username"])
+	assert.Equal(t, true, auth["password_set"])
+	assert.Len(t, body2["notifications"], 1)
+
+	// The channel should have been assigned an ID.
+	ch := body2["notifications"].([]any)[0].(map[string]any)
+	assert.NotEmpty(t, ch["id"])
+}
+
+func TestUpdateSettings_EnableAuthWithoutPasswordFails(t *testing.T) {
+	store := newSettingsStore(t)
+	body := `{"auth":{"enabled":true,"username":"admin"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	v1.UpdateSettings(store).ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateToken_ShownOnceThenListedWithoutSecret(t *testing.T) {
+	store := newSettingsStore(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/settings/tokens", bytes.NewBufferString(`{"name":"ci"}`))
+	rr := httptest.NewRecorder()
+	v1.CreateToken(store).ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+	raw, ok := created["token"].(string)
+	require.True(t, ok)
+	assert.NotEmpty(t, raw)
+
+	// List must not include the raw token or its hash.
+	rr = httptest.NewRecorder()
+	v1.ListTokens(store).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/settings/tokens", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), raw)
+	assert.NotContains(t, rr.Body.String(), "hash")
+
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+	assert.Equal(t, "ci", list[0]["name"])
+}
+
+func TestCreateSchedule_AndInvalidDomain(t *testing.T) {
+	store := newSettingsStore(t)
+	r := chi.NewRouter()
+	r.Post("/api/v1/settings/schedules", v1.CreateSchedule(store))
+	r.Get("/api/v1/settings/schedules", v1.ListSchedules(store))
+
+	// Valid.
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/schedules",
+		bytes.NewBufferString(`{"name":"watch","domain":"example.com","type":"A","interval_sec":300,"enabled":true}`)))
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	// Invalid domain.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/schedules",
+		bytes.NewBufferString(`{"name":"bad","domain":"not a domain!","type":"A"}`)))
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// List shows the one valid schedule.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/settings/schedules", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	assert.Len(t, list, 1)
+}

--- a/internal/settings/secret.go
+++ b/internal/settings/secret.go
@@ -1,0 +1,94 @@
+package settings
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// argon2id parameters. Tuned for interactive logins / token checks.
+const (
+	argonTime    = 1
+	argonMemory  = 64 * 1024 // 64 MiB
+	argonThreads = 4
+	argonKeyLen  = 32
+	argonSaltLen = 16
+)
+
+// ErrInvalidHash is returned when an encoded hash cannot be parsed.
+var ErrInvalidHash = errors.New("invalid argon2id hash format")
+
+// HashSecret hashes a password or token with argon2id and returns the standard
+// encoded representation ($argon2id$v=19$m=...,t=...,p=...$salt$hash).
+func HashSecret(secret string) (string, error) {
+	salt := make([]byte, argonSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("generating salt: %w", err)
+	}
+
+	hash := argon2.IDKey([]byte(secret), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+
+	b64 := base64.RawStdEncoding
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version, argonMemory, argonTime, argonThreads,
+		b64.EncodeToString(salt), b64.EncodeToString(hash),
+	), nil
+}
+
+// VerifySecret reports whether secret matches the given encoded argon2id hash.
+func VerifySecret(secret, encoded string) bool {
+	parts := strings.Split(encoded, "$")
+	// ["", "argon2id", "v=19", "m=...,t=...,p=...", salt, hash]
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false
+	}
+
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil || version != argon2.Version {
+		return false
+	}
+
+	var memory uint32
+	var time uint32
+	var threads uint8
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &time, &threads); err != nil {
+		return false
+	}
+
+	b64 := base64.RawStdEncoding
+	salt, err := b64.DecodeString(parts[4])
+	if err != nil {
+		return false
+	}
+	want, err := b64.DecodeString(parts[5])
+	if err != nil {
+		return false
+	}
+
+	got := argon2.IDKey([]byte(secret), salt, time, memory, threads, uint32(len(want)))
+	return subtle.ConstantTimeCompare(got, want) == 1
+}
+
+// GenerateToken returns a new random URL-safe token string suitable for an API
+// bearer token. It has ~256 bits of entropy.
+func GenerateToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generating token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// NewID returns a short random hex identifier for tokens, schedules, and
+// notification channels.
+func NewID() string {
+	buf := make([]byte, 8)
+	_, _ = rand.Read(buf)
+	return hex.EncodeToString(buf)
+}

--- a/internal/settings/secret_test.go
+++ b/internal/settings/secret_test.go
@@ -1,0 +1,39 @@
+package settings
+
+import "testing"
+
+func TestHashVerifySecret(t *testing.T) {
+	hash, err := HashSecret("s3cret-password")
+	if err != nil {
+		t.Fatalf("HashSecret: %v", err)
+	}
+	if hash == "s3cret-password" {
+		t.Fatal("hash must not equal the plaintext")
+	}
+
+	if !VerifySecret("s3cret-password", hash) {
+		t.Error("VerifySecret returned false for the correct secret")
+	}
+	if VerifySecret("wrong-password", hash) {
+		t.Error("VerifySecret returned true for a wrong secret")
+	}
+}
+
+func TestVerifySecretRejectsGarbage(t *testing.T) {
+	for _, bad := range []string{"", "not-a-hash", "$argon2id$bad", "$bcrypt$v=1$x$y$z"} {
+		if VerifySecret("x", bad) {
+			t.Errorf("VerifySecret(%q) = true, want false", bad)
+		}
+	}
+}
+
+func TestGenerateTokenUnique(t *testing.T) {
+	a, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	b, _ := GenerateToken()
+	if a == "" || a == b {
+		t.Errorf("tokens should be non-empty and unique: %q vs %q", a, b)
+	}
+}

--- a/internal/settings/session.go
+++ b/internal/settings/session.go
@@ -1,0 +1,53 @@
+package settings
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SessionCookie is the name of the UI session cookie.
+const SessionCookie = "dnsmon_session"
+
+// SignSession returns a signed session token for username that expires after
+// ttl. The token format is base64url(username|expiryUnix).hexHMAC, signed with
+// secret. ParseSession reverses it.
+func SignSession(secret, username string, ttl time.Duration) string {
+	payload := username + "|" + strconv.FormatInt(time.Now().Add(ttl).Unix(), 10)
+	enc := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return enc + "." + sign(secret, enc)
+}
+
+// ParseSession validates a session token and returns the username it carries.
+// It returns ok=false if the signature is invalid or the token has expired.
+func ParseSession(secret, token string) (username string, ok bool) {
+	enc, mac, found := strings.Cut(token, ".")
+	if !found {
+		return "", false
+	}
+	if !hmac.Equal([]byte(mac), []byte(sign(secret, enc))) {
+		return "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(enc)
+	if err != nil {
+		return "", false
+	}
+	name, expStr, found := strings.Cut(string(raw), "|")
+	if !found {
+		return "", false
+	}
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil || time.Now().Unix() >= exp {
+		return "", false
+	}
+	return name, true
+}
+
+func sign(secret, msg string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(msg))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/internal/settings/session_test.go
+++ b/internal/settings/session_test.go
@@ -1,0 +1,41 @@
+package settings
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignParseSession(t *testing.T) {
+	secret, _ := GenerateToken()
+
+	token := SignSession(secret, "admin", time.Hour)
+	name, ok := ParseSession(secret, token)
+	if !ok || name != "admin" {
+		t.Fatalf("ParseSession = (%q, %v), want (admin, true)", name, ok)
+	}
+}
+
+func TestParseSessionRejects(t *testing.T) {
+	secret, _ := GenerateToken()
+	token := SignSession(secret, "admin", time.Hour)
+
+	// Wrong secret.
+	if _, ok := ParseSession("other-secret", token); ok {
+		t.Error("expected failure with wrong secret")
+	}
+	// Tampered payload (valid token with its payload swapped).
+	if _, ok := ParseSession(secret, "AAAA."+token); ok {
+		t.Error("expected failure with tampered payload")
+	}
+	// Garbage.
+	for _, bad := range []string{"", "nodot", "a.b.c"} {
+		if _, ok := ParseSession(secret, bad); ok {
+			t.Errorf("ParseSession(%q) = true, want false", bad)
+		}
+	}
+	// Expired.
+	expired := SignSession(secret, "admin", -time.Minute)
+	if _, ok := ParseSession(secret, expired); ok {
+		t.Error("expected failure for expired token")
+	}
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,0 +1,74 @@
+// Package settings holds the user-editable application configuration that is
+// persisted via the storage layer and managed from the /settings page:
+// notification channels, optional UI authentication, external API tokens,
+// resolver enable/disable state, and monitoring schedules.
+package settings
+
+import "time"
+
+// Channel type identifiers for NotificationChannel.Type.
+const (
+	ChannelShoutrrr = "shoutrrr" // generic, via github.com/containrrr/shoutrrr (PR2)
+	ChannelGreenAPI = "greenapi" // WhatsApp via GreenAPI cloud REST (PR2)
+	ChannelGoWA     = "gowa"     // WhatsApp via a self-hosted go-whatsapp-web-multidevice instance (PR2)
+)
+
+// Settings is the singleton application configuration editable from the UI.
+type Settings struct {
+	Auth              AuthSettings          `json:"auth"`
+	Notifications     []NotificationChannel `json:"notifications"`
+	DisabledResolvers []string              `json:"disabled_resolvers"`
+}
+
+// AuthSettings controls optional username/password protection of the UI.
+type AuthSettings struct {
+	Enabled bool   `json:"enabled"`
+	Username string `json:"username"`
+	// PasswordHash is the argon2id-encoded admin password. It is persisted but
+	// never exposed to API clients (the handler layer redacts it).
+	PasswordHash string `json:"password_hash"`
+}
+
+// NotificationChannel describes one configured notification target. The Config
+// map holds type-specific fields (e.g. shoutrrr "url"; greenapi "instance_id"
+// and "token"; gowa "base_url", "username", "password", "recipient").
+type NotificationChannel struct {
+	ID      string            `json:"id"`
+	Type    string            `json:"type"`
+	Name    string            `json:"name"`
+	Enabled bool              `json:"enabled"`
+	Config  map[string]string `json:"config"`
+}
+
+// APIToken is an external bearer token. The raw secret is shown once at creation;
+// only its argon2id hash is persisted.
+type APIToken struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Hash       string     `json:"-"`
+	Prefix     string     `json:"prefix"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+}
+
+// Schedule defines a recurring propagation check for monitoring a record.
+// Execution is implemented in a later change; this stores the definition only.
+type Schedule struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Domain      string    `json:"domain"`
+	Type        string    `json:"type"`
+	Resolvers   []string  `json:"resolvers"`
+	IntervalSec int       `json:"interval_sec"`
+	Enabled     bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Default returns an empty Settings with sensible zero values.
+func Default() *Settings {
+	return &Settings{
+		Notifications:     []NotificationChannel{},
+		DisabledResolvers: []string{},
+	}
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -18,6 +18,9 @@ type Settings struct {
 	Auth              AuthSettings          `json:"auth"`
 	Notifications     []NotificationChannel `json:"notifications"`
 	DisabledResolvers []string              `json:"disabled_resolvers"`
+	// SessionSecret signs UI session cookies. Generated on demand; persisted
+	// but never exposed to API clients.
+	SessionSecret string `json:"session_secret"`
 }
 
 // AuthSettings controls optional username/password protection of the UI.

--- a/internal/storage/postgres/migrations/0002_settings.sql
+++ b/internal/storage/postgres/migrations/0002_settings.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    data BYTEA NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    hash TEXT NOT NULL,
+    prefix TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS schedules (
+    id TEXT PRIMARY KEY,
+    data BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_schedules_created_at ON schedules(created_at);

--- a/internal/storage/postgres/settings.go
+++ b/internal/storage/postgres/settings.go
@@ -1,0 +1,147 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+// GetSettings returns the singleton settings document, or defaults if unset.
+func (s *Store) GetSettings(ctx context.Context) (*settings.Settings, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT data FROM settings WHERE id = 1`)
+
+	var data []byte
+	if err := row.Scan(&data); err != nil {
+		if err == sql.ErrNoRows {
+			return settings.Default(), nil
+		}
+		return nil, fmt.Errorf("scanning settings row: %w", err)
+	}
+
+	var out settings.Settings
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("unmarshaling settings: %w", err)
+	}
+	return &out, nil
+}
+
+// SaveSettings upserts the singleton settings document.
+func (s *Store) SaveSettings(ctx context.Context, in *settings.Settings) error {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("marshaling settings: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO settings (id, data) VALUES (1, $1)
+		 ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data`, data)
+	if err != nil {
+		return fmt.Errorf("saving settings: %w", err)
+	}
+	return nil
+}
+
+// ListAPITokens returns all API tokens ordered by creation time.
+func (s *Store) ListAPITokens(ctx context.Context) ([]*settings.APIToken, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, hash, prefix, created_at, last_used_at FROM api_tokens ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying api tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []*settings.APIToken
+	for rows.Next() {
+		var (
+			t        settings.APIToken
+			lastUsed sql.NullTime
+		)
+		if err := rows.Scan(&t.ID, &t.Name, &t.Hash, &t.Prefix, &t.CreatedAt, &lastUsed); err != nil {
+			return nil, fmt.Errorf("scanning api token row: %w", err)
+		}
+		if lastUsed.Valid {
+			tm := lastUsed.Time
+			t.LastUsedAt = &tm
+		}
+		tokens = append(tokens, &t)
+	}
+	return tokens, rows.Err()
+}
+
+// CreateAPIToken inserts a new API token.
+func (s *Store) CreateAPIToken(ctx context.Context, t *settings.APIToken) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO api_tokens (id, name, hash, prefix, created_at) VALUES ($1, $2, $3, $4, $5)`,
+		t.ID, t.Name, t.Hash, t.Prefix, t.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("creating api token: %w", err)
+	}
+	return nil
+}
+
+// DeleteAPIToken removes an API token by ID.
+func (s *Store) DeleteAPIToken(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM api_tokens WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("deleting api token: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}
+
+// ListSchedules returns all schedules ordered by creation time.
+func (s *Store) ListSchedules(ctx context.Context) ([]*settings.Schedule, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT data FROM schedules ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying schedules: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*settings.Schedule
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("scanning schedule row: %w", err)
+		}
+		var sc settings.Schedule
+		if err := json.Unmarshal(data, &sc); err != nil {
+			return nil, fmt.Errorf("unmarshaling schedule: %w", err)
+		}
+		out = append(out, &sc)
+	}
+	return out, rows.Err()
+}
+
+// SaveSchedule upserts a schedule.
+func (s *Store) SaveSchedule(ctx context.Context, sc *settings.Schedule) error {
+	data, err := json.Marshal(sc)
+	if err != nil {
+		return fmt.Errorf("marshaling schedule: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO schedules (id, data, created_at, updated_at) VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
+		sc.ID, data, sc.CreatedAt, sc.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("saving schedule: %w", err)
+	}
+	return nil
+}
+
+// DeleteSchedule removes a schedule by ID.
+func (s *Store) DeleteSchedule(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM schedules WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("deleting schedule: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}

--- a/internal/storage/sqlite/migrations/0002_settings.sql
+++ b/internal/storage/sqlite/migrations/0002_settings.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    data BLOB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    hash TEXT NOT NULL,
+    prefix TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    last_used_at DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS schedules (
+    id TEXT PRIMARY KEY,
+    data BLOB NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_schedules_created_at ON schedules(created_at);

--- a/internal/storage/sqlite/settings.go
+++ b/internal/storage/sqlite/settings.go
@@ -1,0 +1,150 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+// GetSettings returns the singleton settings document, or defaults if unset.
+func (s *Store) GetSettings(ctx context.Context) (*settings.Settings, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT data FROM settings WHERE id = 1`)
+
+	var data []byte
+	if err := row.Scan(&data); err != nil {
+		if err == sql.ErrNoRows {
+			return settings.Default(), nil
+		}
+		return nil, fmt.Errorf("scanning settings row: %w", err)
+	}
+
+	var out settings.Settings
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("unmarshaling settings: %w", err)
+	}
+	return &out, nil
+}
+
+// SaveSettings upserts the singleton settings document.
+func (s *Store) SaveSettings(ctx context.Context, in *settings.Settings) error {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("marshaling settings: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT OR REPLACE INTO settings (id, data) VALUES (1, ?)`, data)
+	if err != nil {
+		return fmt.Errorf("saving settings: %w", err)
+	}
+	return nil
+}
+
+// ListAPITokens returns all API tokens ordered by creation time.
+func (s *Store) ListAPITokens(ctx context.Context) ([]*settings.APIToken, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, hash, prefix, created_at, last_used_at FROM api_tokens ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying api tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []*settings.APIToken
+	for rows.Next() {
+		var (
+			t        settings.APIToken
+			created  string
+			lastUsed sql.NullString
+		)
+		if err := rows.Scan(&t.ID, &t.Name, &t.Hash, &t.Prefix, &created, &lastUsed); err != nil {
+			return nil, fmt.Errorf("scanning api token row: %w", err)
+		}
+		t.CreatedAt, _ = time.Parse(time.RFC3339, created)
+		if lastUsed.Valid {
+			if tm, err := time.Parse(time.RFC3339, lastUsed.String); err == nil {
+				t.LastUsedAt = &tm
+			}
+		}
+		tokens = append(tokens, &t)
+	}
+	return tokens, rows.Err()
+}
+
+// CreateAPIToken inserts a new API token.
+func (s *Store) CreateAPIToken(ctx context.Context, t *settings.APIToken) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO api_tokens (id, name, hash, prefix, created_at) VALUES (?, ?, ?, ?, ?)`,
+		t.ID, t.Name, t.Hash, t.Prefix, t.CreatedAt.UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("creating api token: %w", err)
+	}
+	return nil
+}
+
+// DeleteAPIToken removes an API token by ID.
+func (s *Store) DeleteAPIToken(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM api_tokens WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting api token: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}
+
+// ListSchedules returns all schedules ordered by creation time.
+func (s *Store) ListSchedules(ctx context.Context) ([]*settings.Schedule, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT data FROM schedules ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying schedules: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*settings.Schedule
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("scanning schedule row: %w", err)
+		}
+		var sc settings.Schedule
+		if err := json.Unmarshal(data, &sc); err != nil {
+			return nil, fmt.Errorf("unmarshaling schedule: %w", err)
+		}
+		out = append(out, &sc)
+	}
+	return out, rows.Err()
+}
+
+// SaveSchedule upserts a schedule.
+func (s *Store) SaveSchedule(ctx context.Context, sc *settings.Schedule) error {
+	data, err := json.Marshal(sc)
+	if err != nil {
+		return fmt.Errorf("marshaling schedule: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO schedules (id, data, created_at, updated_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at`,
+		sc.ID, data, sc.CreatedAt.UTC().Format(time.RFC3339), sc.UpdatedAt.UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("saving schedule: %w", err)
+	}
+	return nil
+}
+
+// DeleteSchedule removes a schedule by ID.
+func (s *Store) DeleteSchedule(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM schedules WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting schedule: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}

--- a/internal/storage/sqlite/settings_test.go
+++ b/internal/storage/sqlite/settings_test.go
@@ -1,0 +1,105 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/t0mer/dnsmon/internal/settings"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(context.Background(), "file:"+t.TempDir()+"/test.db?_fk=1")
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestSettingsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	// Defaults when unset.
+	got, err := s.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSettings (empty): %v", err)
+	}
+	if got.Auth.Enabled {
+		t.Error("expected auth disabled by default")
+	}
+
+	want := settings.Default()
+	want.Auth = settings.AuthSettings{Enabled: true, Username: "admin", PasswordHash: "$argon2id$..."}
+	want.Notifications = []settings.NotificationChannel{
+		{ID: "c1", Type: settings.ChannelShoutrrr, Name: "ops", Enabled: true, Config: map[string]string{"url": "slack://x"}},
+	}
+	want.DisabledResolvers = []string{"google-us", "cloudflare"}
+
+	if err := s.SaveSettings(ctx, want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	got, err = s.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if !got.Auth.Enabled || got.Auth.Username != "admin" || got.Auth.PasswordHash == "" {
+		t.Errorf("auth not persisted: %+v", got.Auth)
+	}
+	if len(got.Notifications) != 1 || got.Notifications[0].Config["url"] != "slack://x" {
+		t.Errorf("notifications not persisted: %+v", got.Notifications)
+	}
+	if len(got.DisabledResolvers) != 2 {
+		t.Errorf("disabled resolvers not persisted: %+v", got.DisabledResolvers)
+	}
+}
+
+func TestAPITokenCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	tok := &settings.APIToken{ID: "t1", Name: "ci", Hash: "$argon2id$...", Prefix: "abcd", CreatedAt: time.Now().UTC()}
+	if err := s.CreateAPIToken(ctx, tok); err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	list, err := s.ListAPITokens(ctx)
+	if err != nil || len(list) != 1 || list[0].Name != "ci" {
+		t.Fatalf("ListAPITokens = %+v, err %v", list, err)
+	}
+	if err := s.DeleteAPIToken(ctx, "t1"); err != nil {
+		t.Fatalf("DeleteAPIToken: %v", err)
+	}
+	if list, _ := s.ListAPITokens(ctx); len(list) != 0 {
+		t.Errorf("expected no tokens after delete, got %d", len(list))
+	}
+}
+
+func TestScheduleCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	now := time.Now().UTC()
+	sc := &settings.Schedule{ID: "s1", Name: "watch example", Domain: "example.com", Type: "A",
+		IntervalSec: 300, Enabled: true, CreatedAt: now, UpdatedAt: now}
+	if err := s.SaveSchedule(ctx, sc); err != nil {
+		t.Fatalf("SaveSchedule: %v", err)
+	}
+	// Update (upsert).
+	sc.Name = "renamed"
+	sc.UpdatedAt = now.Add(time.Minute)
+	if err := s.SaveSchedule(ctx, sc); err != nil {
+		t.Fatalf("SaveSchedule update: %v", err)
+	}
+	list, err := s.ListSchedules(ctx)
+	if err != nil || len(list) != 1 || list[0].Name != "renamed" {
+		t.Fatalf("ListSchedules = %+v, err %v", list, err)
+	}
+	if err := s.DeleteSchedule(ctx, "s1"); err != nil {
+		t.Fatalf("DeleteSchedule: %v", err)
+	}
+	if list, _ := s.ListSchedules(ctx); len(list) != 0 {
+		t.Errorf("expected no schedules after delete, got %d", len(list))
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -5,18 +5,34 @@ import (
 	"errors"
 
 	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/settings"
 )
 
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("not found")
 
-// Storage persists DNS checks.
+// Storage persists DNS checks and user-editable application settings.
 type Storage interface {
 	SaveCheck(ctx context.Context, check *dnsclient.Check) error
 	GetCheck(ctx context.Context, id string) (*dnsclient.Check, error)
 	ListChecks(ctx context.Context, limit, offset int) ([]*dnsclient.Check, error)
 	DeleteCheck(ctx context.Context, id string) error
 	PurgeOldChecks(ctx context.Context, retentionDays int) error
+
+	// Settings (singleton document).
+	GetSettings(ctx context.Context) (*settings.Settings, error)
+	SaveSettings(ctx context.Context, s *settings.Settings) error
+
+	// External API tokens.
+	ListAPITokens(ctx context.Context) ([]*settings.APIToken, error)
+	CreateAPIToken(ctx context.Context, t *settings.APIToken) error
+	DeleteAPIToken(ctx context.Context, id string) error
+
+	// Monitoring schedules.
+	ListSchedules(ctx context.Context) ([]*settings.Schedule, error)
+	SaveSchedule(ctx context.Context, s *settings.Schedule) error
+	DeleteSchedule(ctx context.Context, id string) error
+
 	Close() error
 }
 
@@ -36,5 +52,23 @@ func (n *Noop) ListChecks(_ context.Context, _, _ int) ([]*dnsclient.Check, erro
 func (n *Noop) DeleteCheck(_ context.Context, _ string) error { return nil }
 
 func (n *Noop) PurgeOldChecks(_ context.Context, _ int) error { return nil }
+
+func (n *Noop) GetSettings(_ context.Context) (*settings.Settings, error) {
+	return settings.Default(), nil
+}
+
+func (n *Noop) SaveSettings(_ context.Context, _ *settings.Settings) error { return nil }
+
+func (n *Noop) ListAPITokens(_ context.Context) ([]*settings.APIToken, error) { return nil, nil }
+
+func (n *Noop) CreateAPIToken(_ context.Context, _ *settings.APIToken) error { return nil }
+
+func (n *Noop) DeleteAPIToken(_ context.Context, _ string) error { return nil }
+
+func (n *Noop) ListSchedules(_ context.Context) ([]*settings.Schedule, error) { return nil, nil }
+
+func (n *Noop) SaveSchedule(_ context.Context, _ *settings.Schedule) error { return nil }
+
+func (n *Noop) DeleteSchedule(_ context.Context, _ string) error { return nil }
 
 func (n *Noop) Close() error { return nil }

--- a/web/src/about.html
+++ b/web/src/about.html
@@ -28,6 +28,7 @@
           <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
           <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
           <a href="/api-docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
+          <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>
 
         <!-- Right: dark mode -->

--- a/web/src/css/tailwind.src.css
+++ b/web/src/css/tailwind.src.css
@@ -12,6 +12,7 @@
 @layer components {
   /* Buttons */
   .btn { @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-all duration-150 disabled:opacity-50 disabled:pointer-events-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2; }
+  .btn-sm { @apply inline-flex items-center justify-center gap-1.5 px-2.5 py-1 rounded-md font-medium text-xs transition-colors duration-150 disabled:opacity-50 disabled:pointer-events-none; }
   .btn-primary { @apply btn bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 text-white shadow-sm; }
   .btn-secondary { @apply btn bg-white dark:bg-slate-800 hover:bg-slate-50 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 ring-1 ring-slate-300 dark:ring-slate-700 shadow-sm; }
   .btn-live-off { @apply btn bg-emerald-50 dark:bg-emerald-950/40 hover:bg-emerald-100 dark:hover:bg-emerald-950/60 text-emerald-700 dark:text-emerald-400 ring-1 ring-emerald-200 dark:ring-emerald-900; }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -39,6 +39,7 @@
           <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
           <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
           <a href="/api-docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
+          <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>
 
         <!-- Right: dark mode + mobile menu -->
@@ -63,6 +64,7 @@
         <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">DNS Lookup</a>
         <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Reverse DNS</a>
         <a href="/api-docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
+        <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Settings</a>
       </div>
     </div>
   </nav>

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -511,19 +511,36 @@ function settingsApp() {
     resolvers: [],
     resolverQuery: '',
 
+    // Session
+    currentUser: '',
+
     async init() {
       await this.loadAll();
+    },
+
+    // unauthorized() returns true (and redirects to /login) if the response is a 401.
+    unauthorized(resp) {
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return true;
+      }
+      return false;
     },
 
     async loadAll() {
       this.loading = true;
       try {
-        const [s, tk, sc, rs] = await Promise.all([
-          fetch('/api/v1/settings').then((r) => r.json()),
-          fetch('/api/v1/settings/tokens').then((r) => r.json()),
-          fetch('/api/v1/settings/schedules').then((r) => r.json()),
-          fetch('/api/v1/resolvers').then((r) => r.json()),
+        const sess = await fetch('/api/v1/auth/session').then((r) => r.json()).catch(() => ({}));
+        this.currentUser = sess.authenticated ? sess.username : '';
+
+        const responses = await Promise.all([
+          fetch('/api/v1/settings'),
+          fetch('/api/v1/settings/tokens'),
+          fetch('/api/v1/settings/schedules'),
+          fetch('/api/v1/resolvers'),
         ]);
+        if (responses.some((r) => this.unauthorized(r))) return;
+        const [s, tk, sc, rs] = await Promise.all(responses.map((r) => r.json()));
         this.auth = {
           enabled: !!s.auth.enabled,
           username: s.auth.username || '',
@@ -548,6 +565,11 @@ function settingsApp() {
       setTimeout(() => { this.statusMsg = ''; }, 4000);
     },
 
+    async logout() {
+      await fetch('/api/v1/auth/logout', { method: 'POST' }).catch(() => {});
+      window.location.href = '/login';
+    },
+
     // ---- Settings document (auth + notifications + disabled resolvers) ----
     async saveSettings() {
       this.saving = true;
@@ -566,11 +588,17 @@ function settingsApp() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         });
+        if (this.unauthorized(resp)) return;
         if (!resp.ok) {
           const e = await resp.json().catch(() => ({}));
           throw new Error(e?.error?.message || `HTTP ${resp.status}`);
         }
         const s = await resp.json();
+        // Enabling auth starts requiring a session; send the user to log in.
+        if (s.auth.enabled && !this.currentUser) {
+          window.location.href = '/login';
+          return;
+        }
         this.auth = {
           enabled: !!s.auth.enabled,
           username: s.auth.username || '',
@@ -707,6 +735,40 @@ function settingsApp() {
 }
 
 // ---------------------------------------------------------------------------
+// loginApp — Sign-in page (login.html)
+// ---------------------------------------------------------------------------
+function loginApp() {
+  return {
+    username: '',
+    password: '',
+    loading: false,
+    errorMsg: '',
+
+    async login() {
+      if (!this.username.trim()) return;
+      this.loading = true;
+      this.errorMsg = '';
+      try {
+        const resp = await fetch('/api/v1/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username: this.username.trim(), password: this.password }),
+        });
+        if (!resp.ok) {
+          const e = await resp.json().catch(() => ({}));
+          throw new Error(e?.error?.message || `HTTP ${resp.status}`);
+        }
+        window.location.href = '/settings';
+      } catch (e) {
+        this.errorMsg = e.message;
+      } finally {
+        this.loading = false;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Register Alpine.js components
 // ---------------------------------------------------------------------------
 document.addEventListener('alpine:init', () => {
@@ -714,4 +776,5 @@ document.addEventListener('alpine:init', () => {
   Alpine.data('lookupApp', lookupApp);
   Alpine.data('reverseApp', reverseApp);
   Alpine.data('settingsApp', settingsApp);
+  Alpine.data('loginApp', loginApp);
 });

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -483,10 +483,235 @@ function reverseApp() {
 }
 
 // ---------------------------------------------------------------------------
+// settingsApp — Settings page (settings.html)
+// ---------------------------------------------------------------------------
+function settingsApp() {
+  return {
+    activeTab: 'notifications',
+    loading: true,
+    saving: false,
+    statusMsg: '',
+    statusErr: false,
+
+    // Settings document
+    auth: { enabled: false, username: '', password: '', password_set: false },
+    notifications: [],
+    disabledResolvers: [],
+
+    // API tokens
+    tokens: [],
+    newTokenName: '',
+    createdToken: '',
+
+    // Schedules
+    schedules: [],
+    scheduleForm: { name: '', domain: '', type: 'A', interval_sec: 300, enabled: true },
+
+    // Resolvers
+    resolvers: [],
+    resolverQuery: '',
+
+    async init() {
+      await this.loadAll();
+    },
+
+    async loadAll() {
+      this.loading = true;
+      try {
+        const [s, tk, sc, rs] = await Promise.all([
+          fetch('/api/v1/settings').then((r) => r.json()),
+          fetch('/api/v1/settings/tokens').then((r) => r.json()),
+          fetch('/api/v1/settings/schedules').then((r) => r.json()),
+          fetch('/api/v1/resolvers').then((r) => r.json()),
+        ]);
+        this.auth = {
+          enabled: !!s.auth.enabled,
+          username: s.auth.username || '',
+          password: '',
+          password_set: !!s.auth.password_set,
+        };
+        this.notifications = s.notifications || [];
+        this.disabledResolvers = s.disabled_resolvers || [];
+        this.tokens = tk || [];
+        this.schedules = sc || [];
+        this.resolvers = rs || [];
+      } catch (e) {
+        this.flash('Failed to load settings: ' + e.message, true);
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    flash(msg, err = false) {
+      this.statusMsg = msg;
+      this.statusErr = err;
+      setTimeout(() => { this.statusMsg = ''; }, 4000);
+    },
+
+    // ---- Settings document (auth + notifications + disabled resolvers) ----
+    async saveSettings() {
+      this.saving = true;
+      try {
+        const payload = {
+          auth: {
+            enabled: this.auth.enabled,
+            username: this.auth.username,
+            password: this.auth.password || '',
+          },
+          notifications: this.notifications,
+          disabled_resolvers: this.disabledResolvers,
+        };
+        const resp = await fetch('/api/v1/settings', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!resp.ok) {
+          const e = await resp.json().catch(() => ({}));
+          throw new Error(e?.error?.message || `HTTP ${resp.status}`);
+        }
+        const s = await resp.json();
+        this.auth = {
+          enabled: !!s.auth.enabled,
+          username: s.auth.username || '',
+          password: '',
+          password_set: !!s.auth.password_set,
+        };
+        this.notifications = s.notifications || [];
+        this.disabledResolvers = s.disabled_resolvers || [];
+        this.flash('Settings saved.');
+      } catch (e) {
+        this.flash(e.message, true);
+      } finally {
+        this.saving = false;
+      }
+    },
+
+    // ---- Notification channels ----
+    channelDefaults(type) {
+      if (type === 'shoutrrr') return { url: '' };
+      if (type === 'greenapi') return { instance_id: '', token: '', recipient: '' };
+      if (type === 'gowa') return { base_url: '', username: '', password: '', recipient: '' };
+      return {};
+    },
+    channelFields(type) {
+      return Object.keys(this.channelDefaults(type));
+    },
+    channelTypeLabel(type) {
+      return { shoutrrr: 'Shoutrrr', greenapi: 'WhatsApp (GreenAPI)', gowa: 'WhatsApp (go-whatsapp-web)' }[type] || type;
+    },
+    addChannel(type) {
+      this.notifications.push({ id: '', type, name: '', enabled: true, config: this.channelDefaults(type) });
+    },
+    removeChannel(i) {
+      this.notifications.splice(i, 1);
+    },
+    async testChannel(i) {
+      const resp = await fetch('/api/v1/settings/notifications/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(this.notifications[i]),
+      });
+      const e = await resp.json().catch(() => ({}));
+      this.flash(e?.error?.message || `HTTP ${resp.status}`, !resp.ok);
+    },
+
+    // ---- API tokens ----
+    async createToken() {
+      if (!this.newTokenName.trim()) return;
+      const resp = await fetch('/api/v1/settings/tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: this.newTokenName.trim() }),
+      });
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        this.flash(e?.error?.message || 'Failed to create token', true);
+        return;
+      }
+      const t = await resp.json();
+      this.createdToken = t.token;
+      this.newTokenName = '';
+      this.tokens.unshift({ id: t.id, name: t.name, prefix: t.prefix, created_at: t.created_at });
+    },
+    async deleteToken(id) {
+      const resp = await fetch('/api/v1/settings/tokens/' + id, { method: 'DELETE' });
+      if (resp.ok || resp.status === 204) {
+        this.tokens = this.tokens.filter((t) => t.id !== id);
+        this.flash('Token revoked.');
+      } else {
+        this.flash('Failed to revoke token', true);
+      }
+    },
+
+    // ---- Schedules ----
+    async createSchedule() {
+      const f = this.scheduleForm;
+      if (!f.name.trim() || !f.domain.trim()) return;
+      const resp = await fetch('/api/v1/settings/schedules', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: f.name.trim(),
+          domain: f.domain.trim(),
+          type: f.type,
+          interval_sec: Number(f.interval_sec) || 300,
+          enabled: f.enabled,
+        }),
+      });
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        this.flash(e?.error?.message || 'Failed to create schedule', true);
+        return;
+      }
+      const sc = await resp.json();
+      this.schedules.unshift(sc);
+      this.scheduleForm = { name: '', domain: '', type: 'A', interval_sec: 300, enabled: true };
+      this.flash('Schedule created.');
+    },
+    async deleteSchedule(id) {
+      const resp = await fetch('/api/v1/settings/schedules/' + id, { method: 'DELETE' });
+      if (resp.ok || resp.status === 204) {
+        this.schedules = this.schedules.filter((s) => s.id !== id);
+        this.flash('Schedule deleted.');
+      } else {
+        this.flash('Failed to delete schedule', true);
+      }
+    },
+    intervalLabel(sec) {
+      if (sec % 3600 === 0) return sec / 3600 + 'h';
+      if (sec % 60 === 0) return sec / 60 + 'm';
+      return sec + 's';
+    },
+
+    // ---- Resolver enable/disable ----
+    isResolverEnabled(id) {
+      return !this.disabledResolvers.includes(id);
+    },
+    toggleResolver(id) {
+      if (this.disabledResolvers.includes(id)) {
+        this.disabledResolvers = this.disabledResolvers.filter((x) => x !== id);
+      } else {
+        this.disabledResolvers.push(id);
+      }
+    },
+    get filteredResolvers() {
+      const q = this.resolverQuery.toLowerCase();
+      if (!q) return this.resolvers;
+      return this.resolvers.filter((r) =>
+        (r.name + ' ' + r.country + ' ' + r.city + ' ' + r.ip).toLowerCase().includes(q));
+    },
+
+    countryName,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Register Alpine.js components
 // ---------------------------------------------------------------------------
 document.addEventListener('alpine:init', () => {
   Alpine.data('dnsmonApp', dnsmonApp);
   Alpine.data('lookupApp', lookupApp);
   Alpine.data('reverseApp', reverseApp);
+  Alpine.data('settingsApp', settingsApp);
 });

--- a/web/src/login.html
+++ b/web/src/login.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dnsmon — Sign in</title>
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body class="min-h-screen flex items-center justify-center px-4" x-data="loginApp()">
+
+  <div class="w-full max-w-sm">
+    <div class="flex items-center justify-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-xl mb-6">
+      <svg class="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+      </svg>
+      <span>dnsmon</span>
+    </div>
+
+    <form @submit.prevent="login()" class="card card-body space-y-4">
+      <h1 class="text-lg font-semibold text-slate-900 dark:text-white">Sign in</h1>
+
+      <div x-show="errorMsg" class="px-3 py-2 rounded-lg text-sm bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300 ring-1 ring-rose-200 dark:ring-rose-900" x-text="errorMsg" role="alert"></div>
+
+      <div>
+        <label for="u" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Username</label>
+        <input id="u" type="text" x-model="username" class="input" autocomplete="username" autofocus />
+      </div>
+      <div>
+        <label for="p" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Password</label>
+        <input id="p" type="password" x-model="password" class="input" autocomplete="current-password" />
+      </div>
+
+      <button type="submit" :disabled="loading" class="btn bg-indigo-600 hover:bg-indigo-700 text-white w-full">
+        <span x-text="loading ? 'Signing in…' : 'Sign in'"></span>
+      </button>
+    </form>
+
+    <p class="text-center mt-4 text-xs text-slate-400 dark:text-slate-500">
+      <a href="/" class="hover:text-slate-600 dark:hover:text-slate-300">← Back to dnsmon</a>
+    </p>
+  </div>
+
+  <script defer src="/js/app.js"></script>
+  <script defer src="/vendor/alpine.js"></script>
+</body>
+</html>

--- a/web/src/lookup.html
+++ b/web/src/lookup.html
@@ -28,6 +28,7 @@
           <a href="/lookup" class="nav-link-active px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">DNS Lookup</a>
           <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
           <a href="/api-docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
+          <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>
 
         <!-- Right: dark mode + mobile menu -->
@@ -48,6 +49,7 @@
         <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">DNS Lookup</a>
         <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Reverse DNS</a>
         <a href="/api-docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
+        <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Settings</a>
       </div>
     </div>
   </nav>

--- a/web/src/reverse.html
+++ b/web/src/reverse.html
@@ -38,6 +38,7 @@
           <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
           <a href="/reverse" class="nav-link-active px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Reverse DNS</a>
           <a href="/api-docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
+          <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>
 
         <!-- Right: dark mode + mobile menu -->
@@ -58,6 +59,7 @@
         <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">DNS Lookup</a>
         <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Reverse DNS</a>
         <a href="/api-docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
+        <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Settings</a>
       </div>
     </div>
   </nav>

--- a/web/src/settings.html
+++ b/web/src/settings.html
@@ -49,8 +49,16 @@
 
   <main x-data="settingsApp()" class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
-    <h1 class="text-2xl font-bold text-slate-900 dark:text-white mb-1">Settings</h1>
-    <p class="text-sm text-slate-500 dark:text-slate-400 mb-6">Configure notifications, access control, resolvers, and monitoring.</p>
+    <div class="flex items-start justify-between gap-4 mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-slate-900 dark:text-white mb-1">Settings</h1>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Configure notifications, access control, resolvers, and monitoring.</p>
+      </div>
+      <div x-show="currentUser" class="flex items-center gap-2 flex-shrink-0">
+        <span class="text-xs text-slate-500 dark:text-slate-400">Signed in as <span class="font-medium text-slate-700 dark:text-slate-300" x-text="currentUser"></span></span>
+        <button @click="logout()" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Sign out</button>
+      </div>
+    </div>
 
     <!-- Status toast -->
     <div x-show="statusMsg" x-transition class="mb-4 px-4 py-2.5 rounded-lg text-sm"

--- a/web/src/settings.html
+++ b/web/src/settings.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dnsmon — Settings</title>
+  <meta name="description" content="Configure dnsmon: notification channels, authentication, API tokens, resolvers, and monitoring schedules." />
+  <link rel="stylesheet" href="/css/app.css" />
+  <link rel="stylesheet" href="/vendor/flag-icons/css/flag-icons.min.css" />
+</head>
+<body class="min-h-screen" x-data>
+
+  <!-- Navigation -->
+  <nav class="sticky top-0 z-50 bg-white/90 dark:bg-slate-950/90 backdrop-blur border-b border-slate-200/80 dark:border-slate-800/80">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between h-14">
+        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="dnsmon home">
+          <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+          </svg>
+          <span>dnsmon</span>
+        </a>
+        <div class="hidden md:flex items-center gap-1">
+          <a href="/" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Propagation</a>
+          <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
+          <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
+          <a href="/api-docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
+          <a href="/settings" class="nav-link-active px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Settings</a>
+        </div>
+        <div class="flex items-center gap-1">
+          <button onclick="toggleDark()" class="p-2 rounded-lg text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors" aria-label="Toggle dark mode">
+            <svg class="w-4 h-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            <svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+          </button>
+          <button class="md:hidden p-2 rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors" aria-label="Toggle menu" @click="$refs.mobileNav.classList.toggle('hidden')">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+          </button>
+        </div>
+      </div>
+      <div x-ref="mobileNav" class="hidden md:hidden py-2 space-y-0.5">
+        <a href="/" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Propagation Check</a>
+        <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">DNS Lookup</a>
+        <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Reverse DNS</a>
+        <a href="/api-docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
+        <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Settings</a>
+      </div>
+    </div>
+  </nav>
+
+  <main x-data="settingsApp()" class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    <h1 class="text-2xl font-bold text-slate-900 dark:text-white mb-1">Settings</h1>
+    <p class="text-sm text-slate-500 dark:text-slate-400 mb-6">Configure notifications, access control, resolvers, and monitoring.</p>
+
+    <!-- Status toast -->
+    <div x-show="statusMsg" x-transition class="mb-4 px-4 py-2.5 rounded-lg text-sm"
+      :class="statusErr ? 'bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300 ring-1 ring-rose-200 dark:ring-rose-900' : 'bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 ring-1 ring-emerald-200 dark:ring-emerald-900'"
+      x-text="statusMsg" role="status"></div>
+
+    <!-- Tabs -->
+    <div class="flex flex-wrap gap-1 border-b border-slate-200 dark:border-slate-800 mb-6">
+      <template x-for="tab in [
+        {k:'notifications', l:'Notifications'},
+        {k:'auth', l:'Authentication'},
+        {k:'tokens', l:'API Tokens'},
+        {k:'resolvers', l:'Resolvers'},
+        {k:'schedules', l:'Schedulers'},
+      ]" :key="tab.k">
+        <button @click="activeTab = tab.k"
+          class="px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors"
+          :class="activeTab === tab.k ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'"
+          x-text="tab.l"></button>
+      </template>
+    </div>
+
+    <div x-show="loading" class="py-16 text-center text-slate-400 text-sm">Loading…</div>
+
+    <div x-show="!loading">
+
+      <!-- ============ NOTIFICATIONS ============ -->
+      <section x-show="activeTab === 'notifications'" class="space-y-4">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-sm text-slate-500 dark:text-slate-400 mr-1">Add channel:</span>
+          <template x-for="t in ['shoutrrr','greenapi','gowa']" :key="t">
+            <button @click="addChannel(t)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800" x-text="channelTypeLabel(t)"></button>
+          </template>
+        </div>
+
+        <p x-show="notifications.length === 0" class="text-sm text-slate-400 dark:text-slate-500 py-4">No notification channels configured.</p>
+
+        <template x-for="(ch, i) in notifications" :key="i">
+          <div class="card card-body space-y-3">
+            <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-2">
+                <span class="badge-ok" x-text="channelTypeLabel(ch.type)"></span>
+                <label class="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+                  <input type="checkbox" x-model="ch.enabled" class="rounded" /> Enabled
+                </label>
+              </div>
+              <div class="flex items-center gap-2">
+                <button @click="testChannel(i)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Test</button>
+                <button @click="removeChannel(i)" class="btn-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30">Remove</button>
+              </div>
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Name</label>
+              <input type="text" x-model="ch.name" class="input" placeholder="e.g. Ops alerts" />
+            </div>
+            <div class="grid sm:grid-cols-2 gap-3">
+              <template x-for="field in channelFields(ch.type)" :key="field">
+                <div>
+                  <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1" x-text="field"></label>
+                  <input :type="field.includes('password') || field === 'token' ? 'password' : 'text'"
+                    x-model="ch.config[field]" class="input font-mono text-xs" autocomplete="off" />
+                </div>
+              </template>
+            </div>
+          </div>
+        </template>
+
+        <button @click="saveSettings()" :disabled="saving" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">
+          <span x-text="saving ? 'Saving…' : 'Save notifications'"></span>
+        </button>
+      </section>
+
+      <!-- ============ AUTHENTICATION ============ -->
+      <section x-show="activeTab === 'auth'" class="space-y-4 max-w-lg">
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+          <input type="checkbox" x-model="auth.enabled" class="rounded" />
+          Protect the UI with a username and password
+        </label>
+        <div x-show="auth.enabled" class="space-y-3">
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Username</label>
+            <input type="text" x-model="auth.username" class="input" autocomplete="username" />
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+              Password <span x-show="auth.password_set" class="text-slate-400">(leave blank to keep current)</span>
+            </label>
+            <input type="password" x-model="auth.password" class="input" autocomplete="new-password"
+              :placeholder="auth.password_set ? '••••••••' : 'Set a password'" />
+          </div>
+        </div>
+        <p class="text-xs text-slate-400 dark:text-slate-500">Enforcement of UI login is added in a later release; this stores the credentials.</p>
+        <button @click="saveSettings()" :disabled="saving" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">
+          <span x-text="saving ? 'Saving…' : 'Save authentication'"></span>
+        </button>
+      </section>
+
+      <!-- ============ API TOKENS ============ -->
+      <section x-show="activeTab === 'tokens'" class="space-y-4">
+        <div class="flex flex-wrap items-end gap-2">
+          <div class="flex-1 min-w-[12rem]">
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Token name</label>
+            <input type="text" x-model="newTokenName" class="input" placeholder="e.g. CI pipeline" @keydown.enter="createToken()" />
+          </div>
+          <button @click="createToken()" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">Create token</button>
+        </div>
+
+        <!-- New token shown once -->
+        <div x-show="createdToken" class="card card-body bg-amber-50 dark:bg-amber-950/30 ring-1 ring-amber-200 dark:ring-amber-900">
+          <p class="text-xs text-amber-700 dark:text-amber-300 mb-1.5 font-medium">Copy this token now — it won't be shown again.</p>
+          <div class="flex items-center gap-2">
+            <code class="flex-1 text-xs font-mono break-all bg-white dark:bg-slate-900 rounded px-2 py-1.5" x-text="createdToken"></code>
+            <button @click="navigator.clipboard.writeText(createdToken); flash('Copied.')" class="btn-sm ring-1 ring-amber-300 dark:ring-amber-800">Copy</button>
+            <button @click="createdToken = ''" class="btn-sm">Dismiss</button>
+          </div>
+        </div>
+
+        <p x-show="tokens.length === 0" class="text-sm text-slate-400 dark:text-slate-500 py-4">No API tokens yet.</p>
+        <div x-show="tokens.length > 0" class="card overflow-hidden">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-slate-50/80 dark:bg-slate-800/40 text-xs text-slate-500 dark:text-slate-400">
+                <th class="text-left px-4 py-2.5 font-medium">Name</th>
+                <th class="text-left px-4 py-2.5 font-medium">Prefix</th>
+                <th class="text-left px-4 py-2.5 font-medium">Created</th>
+                <th class="px-4 py-2.5"></th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 dark:divide-slate-800/60">
+              <template x-for="t in tokens" :key="t.id">
+                <tr>
+                  <td class="px-4 py-2.5 text-slate-900 dark:text-white" x-text="t.name"></td>
+                  <td class="px-4 py-2.5 font-mono text-xs text-slate-500" x-text="t.prefix + '…'"></td>
+                  <td class="px-4 py-2.5 text-xs text-slate-400" x-text="new Date(t.created_at).toLocaleString()"></td>
+                  <td class="px-4 py-2.5 text-right">
+                    <button @click="deleteToken(t.id)" class="btn-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30">Revoke</button>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ============ RESOLVERS ============ -->
+      <section x-show="activeTab === 'resolvers'" class="space-y-4">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <input type="text" x-model="resolverQuery" class="input max-w-xs" placeholder="Filter resolvers…" />
+          <span class="text-xs text-slate-400 dark:text-slate-500" x-text="`${disabledResolvers.length} disabled of ${resolvers.length}`"></span>
+        </div>
+        <div class="card overflow-hidden max-h-[28rem] overflow-y-auto divide-y divide-slate-100 dark:divide-slate-800/60">
+          <template x-for="r in filteredResolvers" :key="r.id">
+            <label class="flex items-center gap-3 px-4 py-2.5 hover:bg-slate-50 dark:hover:bg-slate-800/30 cursor-pointer">
+              <input type="checkbox" :checked="isResolverEnabled(r.id)" @change="toggleResolver(r.id)" class="rounded" />
+              <span class="fi rounded-sm ring-1 ring-black/5" :class="'fi-' + (r.country || 'xx').toLowerCase()" aria-hidden="true"></span>
+              <span class="flex-1 min-w-0">
+                <span class="text-sm text-slate-900 dark:text-white" x-text="r.name"></span>
+                <span class="text-xs text-slate-400 dark:text-slate-500 ml-2 font-mono" x-text="r.ip"></span>
+              </span>
+              <span class="text-xs text-slate-400 dark:text-slate-500" x-text="[r.city, r.country].filter(Boolean).join(', ')"></span>
+            </label>
+          </template>
+        </div>
+        <button @click="saveSettings()" :disabled="saving" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">
+          <span x-text="saving ? 'Saving…' : 'Save resolver selection'"></span>
+        </button>
+      </section>
+
+      <!-- ============ SCHEDULERS ============ -->
+      <section x-show="activeTab === 'schedules'" class="space-y-4">
+        <div class="card card-body grid sm:grid-cols-2 gap-3">
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Name</label>
+            <input type="text" x-model="scheduleForm.name" class="input" placeholder="e.g. Watch example.com" />
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Domain</label>
+            <input type="text" x-model="scheduleForm.domain" class="input" placeholder="example.com" />
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Record type</label>
+            <select x-model="scheduleForm.type" class="input">
+              <template x-for="t in ['A','AAAA','CNAME','MX','NS','TXT','CAA','SRV','SOA']" :key="t">
+                <option x-text="t"></option>
+              </template>
+            </select>
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Interval (seconds)</label>
+            <input type="number" min="30" x-model.number="scheduleForm.interval_sec" class="input" />
+          </div>
+          <div class="sm:col-span-2 flex items-center justify-between">
+            <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+              <input type="checkbox" x-model="scheduleForm.enabled" class="rounded" /> Enabled
+            </label>
+            <button @click="createSchedule()" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">Add schedule</button>
+          </div>
+        </div>
+
+        <p x-show="schedules.length === 0" class="text-sm text-slate-400 dark:text-slate-500 py-4">No schedules yet.</p>
+        <div x-show="schedules.length > 0" class="card overflow-hidden">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-slate-50/80 dark:bg-slate-800/40 text-xs text-slate-500 dark:text-slate-400">
+                <th class="text-left px-4 py-2.5 font-medium">Name</th>
+                <th class="text-left px-4 py-2.5 font-medium">Domain</th>
+                <th class="text-left px-4 py-2.5 font-medium">Type</th>
+                <th class="text-left px-4 py-2.5 font-medium">Every</th>
+                <th class="text-left px-4 py-2.5 font-medium">Status</th>
+                <th class="px-4 py-2.5"></th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 dark:divide-slate-800/60">
+              <template x-for="s in schedules" :key="s.id">
+                <tr>
+                  <td class="px-4 py-2.5 text-slate-900 dark:text-white" x-text="s.name"></td>
+                  <td class="px-4 py-2.5 font-mono text-xs" x-text="s.domain"></td>
+                  <td class="px-4 py-2.5" x-text="s.type"></td>
+                  <td class="px-4 py-2.5 text-xs text-slate-500" x-text="intervalLabel(s.interval_sec)"></td>
+                  <td class="px-4 py-2.5">
+                    <span :class="s.enabled ? 'badge-ok' : 'badge-error'" x-text="s.enabled ? 'Enabled' : 'Disabled'"></span>
+                  </td>
+                  <td class="px-4 py-2.5 text-right">
+                    <button @click="deleteSchedule(s.id)" class="btn-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30">Delete</button>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-xs text-slate-400 dark:text-slate-500">Schedule execution and change alerts are added in a later release; this manages the definitions.</p>
+      </section>
+
+    </div>
+  </main>
+
+  <script defer src="/js/app.js"></script>
+  <script defer src="/vendor/alpine.js"></script>
+</body>
+</html>


### PR DESCRIPTION
  ## Summary
  Introduces a `/settings` admin page and the persistence, API, and access control behind it. This is the first slice of a sequenced effort; the behavioural effects of some sections land in follow-up
  PRs (noted below).

  - **Settings page** (`/settings`) with five sections: Notifications, Authentication, API Tokens, Resolvers (enable/disable), Schedulers.
  - **Persistence:** new `settings`, `api_tokens`, and `schedules` tables via the existing storage interface — implemented for SQLite (default) and Postgres, plus the no-op store. Migrations `0002`.
  - **REST API** under `/api/v1/settings`: get/update settings (secrets redacted), API-token CRUD (raw token shown once), schedule CRUD, and a notifications test stub. OpenAPI spec updated.
  - **Optional UI authentication (enforced):** when enabled, the Settings page and its API require login; public tools (propagation, lookup, reverse, API docs) stay open.

  ## Authentication details
  - Single admin username/password, hashed with **argon2id** (`golang.org/x/crypto`, already a dependency — no new module in this PR).
  - Login sets an **HttpOnly, SameSite=Lax session cookie**: an HMAC-SHA256-signed `username|expiry` token, signed with a per-install secret generated on first login and persisted.
  - `RequireAuth` middleware: pass-through when disabled; otherwise pages redirect to `/login`, API returns `401`. Applied to the `/settings` page and the `/api/v1/settings*` group.
  - Auth endpoints: `POST /api/v1/auth/login`, `POST /auth/logout`, `GET /auth/session`. New `/login` page; settings header shows "Signed in as <user>" + Sign out.
  - Enabling auth is itself unauthenticated (runs while auth is still off), so there's no lockout; every request afterward is gated.

  ## Deferred to follow-up PRs (as designed)
  - Sending notifications — Shoutrrr + WhatsApp (GreenAPI / go-whatsapp-web-multidevice). Channel config + a Test button exist; delivery is stubbed (`501`).
  - API-token enforcement for external API access.
  - Filtering disabled resolvers in checks.
  - Executing schedules + DNS-change alerts.

  ## Changes
  - `internal/settings/` — domain types, argon2id hashing, token/ID gen, session sign/verify.
  - `internal/storage/` — interface + sqlite/postgres/noop implementations, migrations `0002`.
  - `internal/api/v1/settings.go`, `auth.go` — handlers; `internal/api/middleware.go` — `RequireAuth`; `server.go` — routes.
  - `internal/api/docs/openapi.yaml` — settings + auth paths and schemas.
  - `web/src/settings.html`, `login.html`, `js/app.js`, `css/tailwind.src.css`, plus Settings nav link across pages.

  ## Test plan
  - [x] `go build ./...`, `go vet`, `go test ./...` pass (argon2, session sign/verify, storage round-trips, settings handlers)
  - [x] Settings read/write/persist across reload (channel, token, schedule)
  - [x] Token raw value shown once, never returned afterward; secrets redacted from GET
  - [x] Auth flow in a browser: disabled serves `/settings`; enabling redirects to `/login`; public pages stay open; logged-out `/settings`→`/login` and API→`401`; wrong password rejected; correct login
   grants access; sign-out re-gates
  - [ ] Real Postgres backend (verified against SQLite; Postgres mirrors the same SQL)