### PR TITLE
feat: exclude disabled resolvers from checks

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -119,7 +119,7 @@ func (c *Checker) Check(ctx context.Context, req CheckRequest) (*dnsclient.Check
 		return nil, err
 	}
 
-	resolverList, err := c.buildResolverList(req)
+	resolverList, err := c.buildResolverList(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +164,9 @@ func (c *Checker) Lookup(ctx context.Context, req LookupRequest) (*dnsclient.Res
 	if req.Resolver == "" {
 		resolver = dnsclient.Resolver{ID: "custom", Name: "Custom", IP: "8.8.8.8", Port: 53, Protocol: "udp"}
 	} else if r, ok := c.registry.Get(req.Resolver); ok {
+		if _, off := c.disabledResolverSet(ctx)[req.Resolver]; off {
+			return nil, fmt.Errorf("resolver is disabled: %s", req.Resolver)
+		}
 		resolver = r
 	} else {
 		resolver = dnsclient.Resolver{
@@ -186,11 +189,16 @@ func (c *Checker) Lookup(ctx context.Context, req LookupRequest) (*dnsclient.Res
 	return result, nil
 }
 
-func (c *Checker) buildResolverList(req CheckRequest) ([]dnsclient.Resolver, error) {
+func (c *Checker) buildResolverList(ctx context.Context, req CheckRequest) ([]dnsclient.Resolver, error) {
+	disabled := c.disabledResolverSet(ctx)
+
 	var list []dnsclient.Resolver
 
 	if len(req.ResolverIDs) > 0 {
 		for _, id := range req.ResolverIDs {
+			if _, off := disabled[id]; off {
+				continue
+			}
 			r, ok := c.registry.Get(id)
 			if !ok {
 				return nil, fmt.Errorf("resolver not found: %s", id)
@@ -198,9 +206,15 @@ func (c *Checker) buildResolverList(req CheckRequest) ([]dnsclient.Resolver, err
 			list = append(list, r)
 		}
 	} else {
-		list = c.registry.All()
+		for _, r := range c.registry.All() {
+			if _, off := disabled[r.ID]; off {
+				continue
+			}
+			list = append(list, r)
+		}
 	}
 
+	// Custom (ad-hoc) resolvers are not subject to the disabled list.
 	list = append(list, req.CustomResolvers...)
 
 	if len(list) > maxResolvers {
@@ -208,6 +222,23 @@ func (c *Checker) buildResolverList(req CheckRequest) ([]dnsclient.Resolver, err
 	}
 
 	return list, nil
+}
+
+// disabledResolverSet returns the set of resolver IDs the operator has disabled
+// in settings. It fails open (empty set) if settings cannot be read.
+func (c *Checker) disabledResolverSet(ctx context.Context) map[string]struct{} {
+	set := make(map[string]struct{})
+	if c.storage == nil {
+		return set
+	}
+	s, err := c.storage.GetSettings(ctx)
+	if err != nil || s == nil {
+		return set
+	}
+	for _, id := range s.DisabledResolvers {
+		set[id] = struct{}{}
+	}
+	return set
 }
 
 func (c *Checker) fanOut(ctx context.Context, name, qtype string, resolverList []dnsclient.Resolver) []dnsclient.ResolverResult {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -12,8 +12,21 @@ import (
 	"github.com/t0mer/dnsmon/internal/config"
 	"github.com/t0mer/dnsmon/internal/dnsclient"
 	"github.com/t0mer/dnsmon/internal/resolvers"
+	"github.com/t0mer/dnsmon/internal/settings"
 	"github.com/t0mer/dnsmon/internal/storage"
 )
+
+// fakeSettingsStore is a Noop store that reports a fixed disabled-resolver set.
+type fakeSettingsStore struct {
+	storage.Noop
+	disabled []string
+}
+
+func (f *fakeSettingsStore) GetSettings(_ context.Context) (*settings.Settings, error) {
+	s := settings.Default()
+	s.DisabledResolvers = f.disabled
+	return s, nil
+}
 
 // mockClient is a fake DNS client for testing.
 type mockClient struct {
@@ -80,6 +93,34 @@ func TestCheck_Success(t *testing.T) {
 	assert.Equal(t, 2, check.Summary.TotalResolvers)
 	assert.Equal(t, 2, check.Summary.Responded)
 	assert.NotEmpty(t, check.ID)
+}
+
+func TestCheck_ExcludesDisabledResolvers(t *testing.T) {
+	res1 := dnsclient.Resolver{ID: "r1", Name: "R1", IP: "1.1.1.1", Port: 53}
+	res2 := dnsclient.Resolver{ID: "r2", Name: "R2", IP: "8.8.8.8", Port: 53}
+
+	client := &mockClient{}
+	reg := testRegistry([]dnsclient.Resolver{res1, res2})
+	store := &fakeSettingsStore{disabled: []string{"r2"}}
+	c := checker.New(client, reg, &mockCache{}, store, testConfig())
+
+	check, err := c.Check(context.Background(), checker.CheckRequest{Name: "example.com", Type: "A"})
+	require.NoError(t, err)
+
+	assert.Len(t, check.Results, 1)
+	assert.Equal(t, 1, check.Summary.TotalResolvers)
+	assert.Equal(t, "r1", check.Results[0].Resolver.ID)
+}
+
+func TestLookup_DisabledResolverRejected(t *testing.T) {
+	res1 := dnsclient.Resolver{ID: "r1", Name: "R1", IP: "1.1.1.1", Port: 53}
+	client := &mockClient{}
+	reg := testRegistry([]dnsclient.Resolver{res1})
+	store := &fakeSettingsStore{disabled: []string{"r1"}}
+	c := checker.New(client, reg, &mockCache{}, store, testConfig())
+
+	_, err := c.Lookup(context.Background(), checker.LookupRequest{Name: "example.com", Type: "A", Resolver: "r1"})
+	assert.Error(t, err)
 }
 
 func TestCheck_OneTimeout(t *testing.T) {

--- a/internal/checker/stream.go
+++ b/internal/checker/stream.go
@@ -40,7 +40,7 @@ func (c *Checker) Stream(ctx context.Context, req StreamRequest) (<-chan *dnscli
 			return
 		}
 
-		resolverList, err := c.buildResolverList(checkReq)
+		resolverList, err := c.buildResolverList(ctx, checkReq)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Resolvers disabled in settings are now skipped by the checker's buildResolverList, so they drop out of propagation checks, the WebSocket stream, and reverse lookups (all share that path). The disabled set is read from settings at check time, so changes take effect without a restart, and it fails open if settings can't be read.

DNS Lookup rejects a resolver referenced by a disabled registry ID. Ad-hoc custom resolvers and the GET /api/v1/resolvers listing are unaffected, so the settings page can still show disabled resolvers to re-enable them.