### PR TITLE
Schedulers: cadence-only definitions with full add/edit/remove

### DIFF
--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -110,20 +110,14 @@ components:
 
     ScheduleInput:
       type: object
-      required: [name, domain, type]
+      required: [name, cron]
       properties:
         name:
           type: string
-        domain:
+        cron:
           type: string
-        type:
-          type: string
-        resolvers:
-          type: array
-          items:
-            type: string
-        interval_sec:
-          type: integer
+          description: A cron macro (@hourly, @daily, @weekly, @monthly, @yearly), an @every duration, or a 5/6-field cron expression.
+          example: "@daily"
         enabled:
           type: boolean
 

--- a/internal/api/v1/settings.go
+++ b/internal/api/v1/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -228,12 +229,9 @@ func ListSchedules(store storage.Storage) http.HandlerFunc {
 }
 
 type scheduleRequest struct {
-	Name        string   `json:"name" validate:"required"`
-	Domain      string   `json:"domain" validate:"required"`
-	Type        string   `json:"type" validate:"required"`
-	Resolvers   []string `json:"resolvers"`
-	IntervalSec int      `json:"interval_sec"`
-	Enabled     bool     `json:"enabled"`
+	Name    string `json:"name" validate:"required"`
+	Cron    string `json:"cron" validate:"required"`
+	Enabled bool   `json:"enabled"`
 }
 
 func (req scheduleRequest) validate(w http.ResponseWriter, r *http.Request) bool {
@@ -241,11 +239,31 @@ func (req scheduleRequest) validate(w http.ResponseWriter, r *http.Request) bool
 		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, err.Error(), nil)
 		return false
 	}
-	if !domainRE.MatchString(req.Domain) {
-		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidDomain, "Invalid domain name.", nil)
+	if !validCron(req.Cron) {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+			"Invalid schedule: use @hourly, @daily, @weekly, @monthly, @yearly, or a 5/6-field cron expression.", nil)
 		return false
 	}
 	return true
+}
+
+// validCron does a light syntactic check: a recognised @macro, an @every
+// duration, or a cron expression with 5 or 6 whitespace-separated fields.
+// Full parsing happens when schedule execution is implemented.
+func validCron(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return false
+	}
+	switch expr {
+	case "@hourly", "@daily", "@weekly", "@monthly", "@yearly", "@annually", "@midnight":
+		return true
+	}
+	if strings.HasPrefix(expr, "@every ") {
+		return len(strings.TrimSpace(strings.TrimPrefix(expr, "@every "))) > 0
+	}
+	n := len(strings.Fields(expr))
+	return n == 5 || n == 6
 }
 
 // CreateSchedule handles POST /api/v1/settings/schedules.
@@ -263,15 +281,12 @@ func CreateSchedule(store storage.Storage) http.HandlerFunc {
 
 		now := time.Now().UTC()
 		sc := &settings.Schedule{
-			ID:          settings.NewID(),
-			Name:        req.Name,
-			Domain:      req.Domain,
-			Type:        req.Type,
-			Resolvers:   req.Resolvers,
-			IntervalSec: req.IntervalSec,
-			Enabled:     req.Enabled,
-			CreatedAt:   now,
-			UpdatedAt:   now,
+			ID:        settings.NewID(),
+			Name:      req.Name,
+			Cron:      strings.TrimSpace(req.Cron),
+			Enabled:   req.Enabled,
+			CreatedAt: now,
+			UpdatedAt: now,
 		}
 		if err := store.SaveSchedule(r.Context(), sc); err != nil {
 			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal,
@@ -309,10 +324,7 @@ func UpdateSchedule(store storage.Storage) http.HandlerFunc {
 		}
 
 		existing.Name = req.Name
-		existing.Domain = req.Domain
-		existing.Type = req.Type
-		existing.Resolvers = req.Resolvers
-		existing.IntervalSec = req.IntervalSec
+		existing.Cron = strings.TrimSpace(req.Cron)
 		existing.Enabled = req.Enabled
 		existing.UpdatedAt = time.Now().UTC()
 

--- a/internal/api/v1/settings_test.go
+++ b/internal/api/v1/settings_test.go
@@ -103,29 +103,41 @@ func TestCreateToken_ShownOnceThenListedWithoutSecret(t *testing.T) {
 	assert.Equal(t, "ci", list[0]["name"])
 }
 
-func TestCreateSchedule_AndInvalidDomain(t *testing.T) {
+func TestCreateSchedule_AndInvalidCron(t *testing.T) {
 	store := newSettingsStore(t)
 	r := chi.NewRouter()
 	r.Post("/api/v1/settings/schedules", v1.CreateSchedule(store))
 	r.Get("/api/v1/settings/schedules", v1.ListSchedules(store))
 
-	// Valid.
+	// Valid macro cadence.
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/schedules",
-		bytes.NewBufferString(`{"name":"watch","domain":"example.com","type":"A","interval_sec":300,"enabled":true}`)))
+		bytes.NewBufferString(`{"name":"nightly","cron":"@daily","enabled":true}`)))
 	require.Equal(t, http.StatusCreated, rr.Code)
 
-	// Invalid domain.
+	// Valid 5-field cron expression.
 	rr = httptest.NewRecorder()
 	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/schedules",
-		bytes.NewBufferString(`{"name":"bad","domain":"not a domain!","type":"A"}`)))
+		bytes.NewBufferString(`{"name":"every15","cron":"*/15 * * * *","enabled":true}`)))
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	// Invalid cron.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/schedules",
+		bytes.NewBufferString(`{"name":"bad","cron":"not-a-cron"}`)))
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	// List shows the one valid schedule.
+	// Missing cron.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/schedules",
+		bytes.NewBufferString(`{"name":"nocron"}`)))
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// List shows the two valid schedules.
 	rr = httptest.NewRecorder()
 	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/settings/schedules", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
 	var list []map[string]any
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
-	assert.Len(t, list, 1)
+	assert.Len(t, list, 2)
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -54,18 +54,16 @@ type APIToken struct {
 	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 }
 
-// Schedule defines a recurring propagation check for monitoring a record.
-// Execution is implemented in a later change; this stores the definition only.
+// Schedule is a reusable cadence (a cron expression or macro such as @daily /
+// @hourly). Monitors attach to a schedule to decide when they run; the schedule
+// itself carries no domain or record. Execution is implemented in a later change.
 type Schedule struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Domain      string    `json:"domain"`
-	Type        string    `json:"type"`
-	Resolvers   []string  `json:"resolvers"`
-	IntervalSec int       `json:"interval_sec"`
-	Enabled     bool      `json:"enabled"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Cron      string    `json:"cron"` // "@hourly", "@daily", or a cron expression
+	Enabled   bool      `json:"enabled"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // Default returns an empty Settings with sensible zero values.

--- a/internal/storage/sqlite/settings_test.go
+++ b/internal/storage/sqlite/settings_test.go
@@ -81,8 +81,8 @@ func TestScheduleCRUD(t *testing.T) {
 	s := newTestStore(t)
 
 	now := time.Now().UTC()
-	sc := &settings.Schedule{ID: "s1", Name: "watch example", Domain: "example.com", Type: "A",
-		IntervalSec: 300, Enabled: true, CreatedAt: now, UpdatedAt: now}
+	sc := &settings.Schedule{ID: "s1", Name: "hourly", Cron: "@hourly",
+		Enabled: true, CreatedAt: now, UpdatedAt: now}
 	if err := s.SaveSchedule(ctx, sc); err != nil {
 		t.Fatalf("SaveSchedule: %v", err)
 	}

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -510,7 +510,8 @@ function settingsApp() {
 
     // Schedules
     schedules: [],
-    scheduleForm: { name: '', domain: '', type: 'A', interval_sec: 300, enabled: true },
+    scheduleForm: { name: '', cadence: '@daily', cron: '', enabled: true },
+    scheduleEditId: '', // '' = adding; otherwise the id being edited
 
     // Resolvers
     resolvers: [],
@@ -736,44 +737,63 @@ function settingsApp() {
       }
     },
 
-    // ---- Schedules ----
-    async createSchedule() {
+    // ---- Schedulers ----
+    // Resolve the cron string from the cadence selector (or the custom field).
+    scheduleCron() {
       const f = this.scheduleForm;
-      if (!f.name.trim() || !f.domain.trim()) return;
-      const resp = await fetch('/api/v1/settings/schedules', {
-        method: 'POST',
+      return f.cadence === 'custom' ? f.cron.trim() : f.cadence;
+    },
+    // Load an existing scheduler into the form for editing.
+    editSchedule(s) {
+      this.scheduleEditId = s.id;
+      const macros = ['@hourly', '@daily', '@weekly', '@monthly'];
+      if (macros.includes(s.cron)) {
+        this.scheduleForm = { name: s.name, cadence: s.cron, cron: '', enabled: s.enabled };
+      } else {
+        this.scheduleForm = { name: s.name, cadence: 'custom', cron: s.cron, enabled: s.enabled };
+      }
+    },
+    cancelScheduleEdit() {
+      this.scheduleEditId = '';
+      this.scheduleForm = { name: '', cadence: '@daily', cron: '', enabled: true };
+    },
+    // Create a new scheduler or update the one being edited.
+    async saveSchedule() {
+      const f = this.scheduleForm;
+      const cron = this.scheduleCron();
+      if (!f.name.trim() || !cron) return;
+
+      const editing = this.scheduleEditId !== '';
+      const url = editing ? '/api/v1/settings/schedules/' + this.scheduleEditId : '/api/v1/settings/schedules';
+      const resp = await fetch(url, {
+        method: editing ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: f.name.trim(),
-          domain: f.domain.trim(),
-          type: f.type,
-          interval_sec: Number(f.interval_sec) || 300,
-          enabled: f.enabled,
-        }),
+        body: JSON.stringify({ name: f.name.trim(), cron, enabled: f.enabled }),
       });
       if (!resp.ok) {
         const e = await resp.json().catch(() => ({}));
-        this.flash(e?.error?.message || 'Failed to create schedule', true);
+        this.flash(e?.error?.message || 'Failed to save scheduler', true);
         return;
       }
       const sc = await resp.json();
-      this.schedules.unshift(sc);
-      this.scheduleForm = { name: '', domain: '', type: 'A', interval_sec: 300, enabled: true };
-      this.flash('Schedule created.');
+      if (editing) {
+        const i = this.schedules.findIndex((x) => x.id === sc.id);
+        if (i !== -1) this.schedules[i] = sc;
+        this.flash('Scheduler updated.');
+      } else {
+        this.schedules.unshift(sc);
+        this.flash('Scheduler created.');
+      }
+      this.cancelScheduleEdit();
     },
     async deleteSchedule(id) {
       const resp = await fetch('/api/v1/settings/schedules/' + id, { method: 'DELETE' });
       if (resp.ok || resp.status === 204) {
         this.schedules = this.schedules.filter((s) => s.id !== id);
-        this.flash('Schedule deleted.');
+        this.flash('Scheduler deleted.');
       } else {
-        this.flash('Failed to delete schedule', true);
+        this.flash('Failed to delete scheduler', true);
       }
-    },
-    intervalLabel(sec) {
-      if (sec % 3600 === 0) return sec / 3600 + 'h';
-      if (sec % 60 === 0) return sec / 60 + 'm';
-      return sec + 's';
     },
 
     // ---- Resolver enable/disable ----

--- a/web/src/settings.html
+++ b/web/src/settings.html
@@ -266,44 +266,50 @@
 
       <!-- ============ SCHEDULERS ============ -->
       <section x-show="activeTab === 'schedules'" class="space-y-4">
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          Define reusable schedules (how often). Monitors will attach to a schedule to decide when they run.
+        </p>
+
         <div class="card card-body grid sm:grid-cols-2 gap-3">
           <div>
             <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Name</label>
-            <input type="text" x-model="scheduleForm.name" class="input" placeholder="e.g. Watch example.com" />
+            <input type="text" x-model="scheduleForm.name" class="input" placeholder="e.g. Hourly checks" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Domain</label>
-            <input type="text" x-model="scheduleForm.domain" class="input" placeholder="example.com" />
-          </div>
-          <div>
-            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Record type</label>
-            <select x-model="scheduleForm.type" class="input">
-              <template x-for="t in ['A','AAAA','CNAME','MX','NS','TXT','CAA','SRV','SOA']" :key="t">
-                <option x-text="t"></option>
-              </template>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Cadence</label>
+            <select x-model="scheduleForm.cadence" class="input">
+              <option value="@hourly">Hourly</option>
+              <option value="@daily">Daily</option>
+              <option value="@weekly">Weekly</option>
+              <option value="@monthly">Monthly</option>
+              <option value="custom">Custom (cron)…</option>
             </select>
           </div>
-          <div>
-            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Interval (seconds)</label>
-            <input type="number" min="30" x-model.number="scheduleForm.interval_sec" class="input" />
+          <div class="sm:col-span-2" x-show="scheduleForm.cadence === 'custom'">
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Cron expression</label>
+            <input type="text" x-model="scheduleForm.cron" class="input font-mono text-xs" placeholder="*/15 * * * *" />
+            <p class="text-xs text-slate-400 dark:text-slate-500 mt-1">5 or 6 fields (min hour dom mon dow), or an @every duration.</p>
           </div>
           <div class="sm:col-span-2 flex items-center justify-between">
             <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
               <input type="checkbox" x-model="scheduleForm.enabled" class="rounded" /> Enabled
             </label>
-            <button @click="createSchedule()" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">Add schedule</button>
+            <div class="flex items-center gap-2">
+              <button x-show="scheduleEditId" @click="cancelScheduleEdit()" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Cancel</button>
+              <button @click="saveSchedule()" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">
+                <span x-text="scheduleEditId ? 'Save changes' : 'Add scheduler'"></span>
+              </button>
+            </div>
           </div>
         </div>
 
-        <p x-show="schedules.length === 0" class="text-sm text-slate-400 dark:text-slate-500 py-4">No schedules yet.</p>
+        <p x-show="schedules.length === 0" class="text-sm text-slate-400 dark:text-slate-500 py-4">No schedulers yet.</p>
         <div x-show="schedules.length > 0" class="card overflow-hidden">
           <table class="w-full text-sm">
             <thead>
               <tr class="bg-slate-50/80 dark:bg-slate-800/40 text-xs text-slate-500 dark:text-slate-400">
                 <th class="text-left px-4 py-2.5 font-medium">Name</th>
-                <th class="text-left px-4 py-2.5 font-medium">Domain</th>
-                <th class="text-left px-4 py-2.5 font-medium">Type</th>
-                <th class="text-left px-4 py-2.5 font-medium">Every</th>
+                <th class="text-left px-4 py-2.5 font-medium">Schedule</th>
                 <th class="text-left px-4 py-2.5 font-medium">Status</th>
                 <th class="px-4 py-2.5"></th>
               </tr>
@@ -312,13 +318,12 @@
               <template x-for="s in schedules" :key="s.id">
                 <tr>
                   <td class="px-4 py-2.5 text-slate-900 dark:text-white" x-text="s.name"></td>
-                  <td class="px-4 py-2.5 font-mono text-xs" x-text="s.domain"></td>
-                  <td class="px-4 py-2.5" x-text="s.type"></td>
-                  <td class="px-4 py-2.5 text-xs text-slate-500" x-text="intervalLabel(s.interval_sec)"></td>
+                  <td class="px-4 py-2.5 font-mono text-xs text-slate-500 dark:text-slate-400" x-text="s.cron"></td>
                   <td class="px-4 py-2.5">
                     <span :class="s.enabled ? 'badge-ok' : 'badge-error'" x-text="s.enabled ? 'Enabled' : 'Disabled'"></span>
                   </td>
-                  <td class="px-4 py-2.5 text-right">
+                  <td class="px-4 py-2.5 text-right whitespace-nowrap">
+                    <button @click="editSchedule(s)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Edit</button>
                     <button @click="deleteSchedule(s.id)" class="btn-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30">Delete</button>
                   </td>
                 </tr>
@@ -326,7 +331,7 @@
             </tbody>
           </table>
         </div>
-        <p class="text-xs text-slate-400 dark:text-slate-500">Schedule execution and change alerts are added in a later release; this manages the definitions.</p>
+        <p class="text-xs text-slate-400 dark:text-slate-500">Schedule execution and attaching monitors are added in a later release; this manages the schedule definitions.</p>
       </section>
 
     </div>


### PR DESCRIPTION
  ## Summary
  Reframe a "scheduler" as a reusable **cadence** (a cron macro or expression), decoupled from any domain or record. A future "monitor" (domain + record type) will attach to a scheduler to decide *when*
   it runs. Also makes schedulers editable, not just add/remove.

  ## Changes
  - **Model** (`internal/settings`): `Schedule` drops `domain` / `type` / `resolvers` / `interval_sec`; now just `name`, `cron`, `enabled` (+ id/timestamps).
  - **API** (`internal/api/v1/settings.go`): `scheduleRequest` is `{name, cron, enabled}`. New `validCron` does a light syntactic check — accepts the macros `@hourly` / `@daily` / `@weekly` / `@monthly`
   / `@yearly` (and `@midnight`/`@annually`), an `@every <dur>`, or a 5- or 6-field cron expression. Create + update handlers updated. (Full cron parsing arrives with schedule execution.)
  - **UI** (`web/src/settings.html`, `web/src/js/app.js`): the Schedulers tab is a **Name + Cadence** form (Hourly / Daily / Weekly / Monthly / **Custom (cron)** — the custom option reveals a cron
  field). The form doubles as an editor: **Edit** pre-fills it and `PUT`s the change in place, **Cancel** resets, Add/Delete unchanged.
  - **Docs**: OpenAPI `ScheduleInput` schema updated (`cron` instead of domain/type/resolvers/interval_sec).
  - Tests updated (storage round-trip, handler create/validation).

  No DB migration — the `schedules` table stores a JSON blob, so the shape change is transparent.

  ## Test plan
  - [x] `go build ./...`, `go vet`, `go test ./...` pass
  - [x] Browser: create a Daily scheduler → stored as `@daily`
  - [x] Custom cadence reveals the cron field; `*/15 * * * *` accepted; invalid (`nope`) rejected with a clear message
  - [x] **Edit** pre-fills the form, switching to custom cron + rename updates the row **in place** (no duplicate) and persists
  - [x] Delete works

  ## Not in scope (future)
  The **monitor** concept (domain + record + attach-to-scheduler), actual schedule execution, and firing notifications on detected DNS changes.