### PR TITLE
Monitors: propagation & change detection with manual run, history, and no-cache checks

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -87,10 +87,12 @@ storage:
 ##############################################################################
 cache:
   # Cache driver. Options: memory | redis | none
+  # Default is "none": checks always query resolvers live so results are never
+  # stale. Monitors always run uncached regardless of this setting.
   # Env: DNSMON_CACHE_DRIVER
-  driver: "memory"
+  driver: "none"
 
-  # How long to cache a (name, type, resolver) response tuple.
+  # How long to cache a (name, type, resolver) response tuple (memory/redis only).
   # Env: DNSMON_CACHE_TTL
   ttl: 60s
 

--- a/deploy/docker-compose.sqlite.yml
+++ b/deploy/docker-compose.sqlite.yml
@@ -13,7 +13,7 @@ services:
       PORT: "8080"
       DNSMON_STORAGE_DRIVER: "sqlite"
       DNSMON_STORAGE_DSN: "file:/data/dnsmon.db?cache=shared&_fk=1"
-      DNSMON_CACHE_DRIVER: "memory"
+      DNSMON_CACHE_DRIVER: "none"
       DNSMON_LOG_FORMAT: "json"
     volumes:
       - dnsmondata:/data

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,11 +107,11 @@ Persistent storage for check history and permalinks.
 
 ## cache
 
-Response caching to reduce redundant DNS queries for popular domains.
+Optional response caching. Disabled by default so every check queries resolvers live (DNS propagation/lookup accuracy depends on fresh answers). Monitors always run uncached regardless of this setting.
 
 | Option | Type | Default | Env Variable | Description |
 |---|---|---|---|---|
-| `driver` | string | `memory` | `DNSMON_CACHE_DRIVER` | Cache backend. Options: `memory` (in-process LRU, default), `redis` (shared cache for multi-replica deployments), `none` (disable caching). |
+| `driver` | string | `none` | `DNSMON_CACHE_DRIVER` | Cache backend. Options: `none` (default — no caching, always live), `memory` (in-process LRU), `redis` (shared cache for multi-replica deployments). |
 | `ttl` | duration | `60s` | `DNSMON_CACHE_TTL` | How long a cached `(name, type, resolver)` response is considered fresh. After expiry the next request triggers a fresh DNS query. |
 | `size` | int | `10000` | `DNSMON_CACHE_SIZE` | Maximum number of entries in the in-memory LRU cache. Only applies when `driver=memory`. When capacity is exceeded, least-recently-used entries are evicted. |
 | `redis_addr` | string | `` | `DNSMON_CACHE_REDIS_ADDR` | Redis server address. Only used when `driver=redis`. Format: `host:port`, e.g. `localhost:6379`. |

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1064,3 +1064,25 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/MonitorEvent'
+
+  /settings/monitors/{id}/run:
+    post:
+      summary: Evaluate a monitor now
+      description: Runs the monitor immediately (propagation check or change comparison), records a changelog entry, and notifies the bound channel on an alert. Returns the resulting event.
+      operationId: runMonitor
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Evaluation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MonitorEvent'
+        '404':
+          description: Not found

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -135,6 +135,67 @@ components:
               type: string
               format: date-time
 
+    MonitorInput:
+      type: object
+      required: [type, fqdn, record_type]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+          enum: [propagation, change]
+        fqdn:
+          type: string
+        record_type:
+          type: string
+        expected:
+          type: array
+          items:
+            type: string
+          description: Required values (propagation) or the baseline (change).
+        scheduler_id:
+          type: string
+        channel_id:
+          type: string
+        enabled:
+          type: boolean
+
+    Monitor:
+      allOf:
+        - $ref: '#/components/schemas/MonitorInput'
+        - type: object
+          properties:
+            id:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+
+    MonitorEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        monitor_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [created, ok, not_propagated, changed, error]
+        observed:
+          type: array
+          items:
+            type: string
+        message:
+          type: string
+        notified:
+          type: boolean
+
     Answer:
       type: object
       properties:
@@ -897,3 +958,109 @@ paths:
           description: Deleted
         '404':
           description: Not found
+
+  /settings/monitors:
+    get:
+      summary: List monitors
+      operationId: listMonitors
+      tags: [Settings]
+      responses:
+        '200':
+          description: Monitors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Monitor'
+    post:
+      summary: Create a monitor
+      operationId: createMonitor
+      tags: [Settings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MonitorInput'
+      responses:
+        '201':
+          description: Created monitor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitor'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /settings/monitors/{id}:
+    put:
+      summary: Update a monitor
+      operationId: updateMonitor
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MonitorInput'
+      responses:
+        '200':
+          description: Updated monitor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitor'
+        '404':
+          description: Not found
+    delete:
+      summary: Delete a monitor
+      operationId: deleteMonitor
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+
+  /settings/monitors/{id}/history:
+    get:
+      summary: Get a monitor's changelog
+      operationId: monitorHistory
+      tags: [Settings]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+      responses:
+        '200':
+          description: Changelog events, most recent first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MonitorEvent'

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/t0mer/dnsmon/internal/api/v1"
 	"github.com/t0mer/dnsmon/internal/checker"
 	"github.com/t0mer/dnsmon/internal/config"
+	"github.com/t0mer/dnsmon/internal/monitor"
 	"github.com/t0mer/dnsmon/internal/notify"
 	"github.com/t0mer/dnsmon/internal/resolvers"
 	"github.com/t0mer/dnsmon/internal/storage"
@@ -150,6 +151,7 @@ func (s *Server) routes() {
 			r.Put("/settings/monitors/{id}", v1.UpdateMonitor(s.storage))
 			r.Delete("/settings/monitors/{id}", v1.DeleteMonitor(s.storage))
 			r.Get("/settings/monitors/{id}/history", v1.MonitorHistory(s.storage))
+			r.Post("/settings/monitors/{id}/run", v1.RunMonitor(monitor.New(s.checker, s.storage, notify.New())))
 		})
 	})
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -144,6 +144,12 @@ func (s *Server) routes() {
 			r.Post("/settings/schedules", v1.CreateSchedule(s.storage))
 			r.Put("/settings/schedules/{id}", v1.UpdateSchedule(s.storage))
 			r.Delete("/settings/schedules/{id}", v1.DeleteSchedule(s.storage))
+
+			r.Get("/settings/monitors", v1.ListMonitors(s.storage))
+			r.Post("/settings/monitors", v1.CreateMonitor(s.storage))
+			r.Put("/settings/monitors/{id}", v1.UpdateMonitor(s.storage))
+			r.Delete("/settings/monitors/{id}", v1.DeleteMonitor(s.storage))
+			r.Get("/settings/monitors/{id}/history", v1.MonitorHistory(s.storage))
 		})
 	})
 

--- a/internal/api/v1/monitors.go
+++ b/internal/api/v1/monitors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/t0mer/dnsmon/internal/api/apierr"
 	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/monitor"
 	"github.com/t0mer/dnsmon/internal/settings"
 	"github.com/t0mer/dnsmon/internal/storage"
 )
@@ -184,6 +185,24 @@ func DeleteMonitor(store storage.Storage) http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// RunMonitor handles POST /api/v1/settings/monitors/{id}/run. It evaluates the
+// monitor immediately and returns the resulting changelog event.
+func RunMonitor(eval *monitor.Evaluator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		event, err := eval.RunByID(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				apierr.WriteError(w, r, http.StatusNotFound, apierr.ErrCodeNotFound, "Monitor not found.", nil)
+				return
+			}
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to run monitor.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusOK, event)
 	}
 }
 

--- a/internal/api/v1/monitors.go
+++ b/internal/api/v1/monitors.go
@@ -1,0 +1,210 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+type monitorRequest struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type" validate:"required"`
+	FQDN        string   `json:"fqdn" validate:"required"`
+	RecordType  string   `json:"record_type" validate:"required"`
+	Expected    []string `json:"expected"`
+	SchedulerID string   `json:"scheduler_id"`
+	ChannelID   string   `json:"channel_id"`
+	Enabled     bool     `json:"enabled"`
+}
+
+func (req *monitorRequest) validate(w http.ResponseWriter, r *http.Request) bool {
+	if err := validate.Struct(req); err != nil {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, err.Error(), nil)
+		return false
+	}
+	if req.Type != settings.MonitorPropagation && req.Type != settings.MonitorChange {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+			"type must be 'propagation' or 'change'.", nil)
+		return false
+	}
+	if !domainRE.MatchString(req.FQDN) {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidDomain, "Invalid FQDN.", nil)
+		return false
+	}
+	if _, ok := dnsclient.ParseType(req.RecordType); !ok {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidRecordType,
+			"Unsupported record type.", nil)
+		return false
+	}
+	if req.Type == settings.MonitorPropagation && len(cleanValues(req.Expected)) == 0 {
+		apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+			"Propagation monitors require at least one expected value.", nil)
+		return false
+	}
+	return true
+}
+
+func cleanValues(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// ListMonitors handles GET /api/v1/settings/monitors.
+func ListMonitors(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		list, err := store.ListMonitors(r.Context())
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to list monitors.", nil)
+			return
+		}
+		if list == nil {
+			list = []*settings.Monitor{}
+		}
+		apierr.WriteJSON(w, http.StatusOK, list)
+	}
+}
+
+// CreateMonitor handles POST /api/v1/settings/monitors.
+func CreateMonitor(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req monitorRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, "Invalid request body.", nil)
+			return
+		}
+		if !req.validate(w, r) {
+			return
+		}
+
+		now := time.Now().UTC()
+		m := &settings.Monitor{
+			ID:          settings.NewID(),
+			Name:        strings.TrimSpace(req.Name),
+			Type:        req.Type,
+			FQDN:        strings.TrimSpace(req.FQDN),
+			RecordType:  req.RecordType,
+			Expected:    cleanValues(req.Expected),
+			SchedulerID: req.SchedulerID,
+			ChannelID:   req.ChannelID,
+			Enabled:     req.Enabled,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if m.Name == "" {
+			m.Name = m.FQDN
+		}
+		if err := store.SaveMonitor(r.Context(), m); err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to create monitor.", nil)
+			return
+		}
+
+		// Seed the changelog with the initial baseline/expected snapshot.
+		_ = store.AppendMonitorEvent(r.Context(), &settings.MonitorEvent{
+			ID:        settings.NewID(),
+			MonitorID: m.ID,
+			Timestamp: now,
+			Status:    settings.MonitorStatusCreated,
+			Observed:  m.Expected,
+			Message:   "Monitor created.",
+		})
+
+		apierr.WriteJSON(w, http.StatusCreated, m)
+	}
+}
+
+// UpdateMonitor handles PUT /api/v1/settings/monitors/{id}.
+func UpdateMonitor(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var req monitorRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput, "Invalid request body.", nil)
+			return
+		}
+		if !req.validate(w, r) {
+			return
+		}
+
+		existing, err := store.GetMonitor(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				apierr.WriteError(w, r, http.StatusNotFound, apierr.ErrCodeNotFound, "Monitor not found.", nil)
+				return
+			}
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to load monitor.", nil)
+			return
+		}
+
+		existing.Name = strings.TrimSpace(req.Name)
+		if existing.Name == "" {
+			existing.Name = strings.TrimSpace(req.FQDN)
+		}
+		existing.Type = req.Type
+		existing.FQDN = strings.TrimSpace(req.FQDN)
+		existing.RecordType = req.RecordType
+		existing.Expected = cleanValues(req.Expected)
+		existing.SchedulerID = req.SchedulerID
+		existing.ChannelID = req.ChannelID
+		existing.Enabled = req.Enabled
+		existing.UpdatedAt = time.Now().UTC()
+
+		if err := store.SaveMonitor(r.Context(), existing); err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to update monitor.", nil)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusOK, existing)
+	}
+}
+
+// DeleteMonitor handles DELETE /api/v1/settings/monitors/{id}.
+func DeleteMonitor(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := store.DeleteMonitor(r.Context(), id); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				apierr.WriteError(w, r, http.StatusNotFound, apierr.ErrCodeNotFound, "Monitor not found.", nil)
+				return
+			}
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to delete monitor.", nil)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// MonitorHistory handles GET /api/v1/settings/monitors/{id}/history.
+func MonitorHistory(store storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		limit := 100
+		if l := r.URL.Query().Get("limit"); l != "" {
+			if n, err := strconv.Atoi(l); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		events, err := store.ListMonitorEvents(r.Context(), id, limit)
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusInternalServerError, apierr.ErrCodeInternal, "Failed to load monitor history.", nil)
+			return
+		}
+		if events == nil {
+			events = []*settings.MonitorEvent{}
+		}
+		apierr.WriteJSON(w, http.StatusOK, events)
+	}
+}

--- a/internal/api/v1/monitors_test.go
+++ b/internal/api/v1/monitors_test.go
@@ -1,0 +1,113 @@
+package v1_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "github.com/t0mer/dnsmon/internal/api/v1"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+func monitorRouter(store storage.Storage) *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/api/v1/settings/monitors", v1.ListMonitors(store))
+	r.Post("/api/v1/settings/monitors", v1.CreateMonitor(store))
+	r.Put("/api/v1/settings/monitors/{id}", v1.UpdateMonitor(store))
+	r.Delete("/api/v1/settings/monitors/{id}", v1.DeleteMonitor(store))
+	r.Get("/api/v1/settings/monitors/{id}/history", v1.MonitorHistory(store))
+	return r
+}
+
+func TestCreateMonitor_PropagationAndChange(t *testing.T) {
+	store := newSettingsStore(t)
+	r := monitorRouter(store)
+
+	// Propagation monitor with expected values.
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/monitors",
+		bytes.NewBufferString(`{"type":"propagation","fqdn":"example.com","record_type":"A","expected":["1.2.3.4"],"enabled":true}`)))
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+	id := created["id"].(string)
+	assert.Equal(t, "example.com", created["name"]) // name defaults to FQDN
+
+	// Change monitor (no expected required).
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/monitors",
+		bytes.NewBufferString(`{"type":"change","name":"drift","fqdn":"example.org","record_type":"AAAA","expected":["::1"]}`)))
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	// The propagation monitor's changelog has the initial "created" event.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/settings/monitors/"+id+"/history", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var events []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &events))
+	require.Len(t, events, 1)
+	assert.Equal(t, "created", events[0]["status"])
+
+	// List shows both.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/settings/monitors", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	assert.Len(t, list, 2)
+}
+
+func TestCreateMonitor_Validation(t *testing.T) {
+	store := newSettingsStore(t)
+	r := monitorRouter(store)
+
+	cases := []string{
+		`{"type":"propagation","fqdn":"example.com","record_type":"A"}`,      // propagation needs expected
+		`{"type":"bogus","fqdn":"example.com","record_type":"A","expected":["x"]}`, // bad type
+		`{"type":"change","fqdn":"bad domain!","record_type":"A"}`,           // bad fqdn
+		`{"type":"change","fqdn":"example.com","record_type":"ZZZ"}`,         // bad record type
+	}
+	for _, body := range cases {
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/monitors", bytes.NewBufferString(body)))
+		assert.Equal(t, http.StatusBadRequest, rr.Code, body)
+	}
+}
+
+func TestUpdateAndDeleteMonitor(t *testing.T) {
+	store := newSettingsStore(t)
+	r := monitorRouter(store)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/settings/monitors",
+		bytes.NewBufferString(`{"type":"change","fqdn":"example.com","record_type":"A","expected":["1.2.3.4"]}`)))
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+	id := created["id"].(string)
+
+	// Update.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPut, "/api/v1/settings/monitors/"+id,
+		bytes.NewBufferString(`{"type":"change","name":"renamed","fqdn":"example.com","record_type":"A","expected":["5.6.7.8"]}`)))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var updated map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &updated))
+	assert.Equal(t, "renamed", updated["name"])
+
+	// Delete.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodDelete, "/api/v1/settings/monitors/"+id, nil))
+	require.Equal(t, http.StatusNoContent, rr.Code)
+
+	// Update missing -> 404.
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPut, "/api/v1/settings/monitors/"+id,
+		bytes.NewBufferString(`{"type":"change","fqdn":"example.com","record_type":"A","expected":["x"]}`)))
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -31,6 +31,9 @@ type CheckRequest struct {
 	CustomResolvers []dnsclient.Resolver
 	Save            bool
 	AllowPrivate    bool
+	// NoCache forces a fresh query to every resolver, bypassing the response
+	// cache (used by monitors so each run is a full live test).
+	NoCache bool
 }
 
 // LookupRequest describes a single-resolver detailed lookup.
@@ -124,7 +127,7 @@ func (c *Checker) Check(ctx context.Context, req CheckRequest) (*dnsclient.Check
 		return nil, err
 	}
 
-	results := c.fanOut(ctx, req.Name, req.Type, resolverList)
+	results := c.fanOut(ctx, req.Name, req.Type, resolverList, req.NoCache)
 
 	check := &dnsclient.Check{
 		ID:        NewID(req.Name, req.Type),
@@ -241,7 +244,7 @@ func (c *Checker) disabledResolverSet(ctx context.Context) map[string]struct{} {
 	return set
 }
 
-func (c *Checker) fanOut(ctx context.Context, name, qtype string, resolverList []dnsclient.Resolver) []dnsclient.ResolverResult {
+func (c *Checker) fanOut(ctx context.Context, name, qtype string, resolverList []dnsclient.Resolver, noCache bool) []dnsclient.ResolverResult {
 	concurrency := c.cfg.DNS.PerResolverConcurrency
 	if concurrency <= 0 {
 		concurrency = 4
@@ -258,7 +261,7 @@ func (c *Checker) fanOut(ctx context.Context, name, qtype string, resolverList [
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			result := c.queryWithCache(ctx, resolver, name, qtype)
+			result := c.queryWithCache(ctx, resolver, name, qtype, noCache)
 			results[idx] = *result
 
 			c.m.queryTotal.WithLabelValues(resolver.ID, result.Status).Inc()
@@ -271,17 +274,20 @@ func (c *Checker) fanOut(ctx context.Context, name, qtype string, resolverList [
 	return results
 }
 
-func (c *Checker) queryWithCache(ctx context.Context, resolver dnsclient.Resolver, name, qtype string) *dnsclient.ResolverResult {
+func (c *Checker) queryWithCache(ctx context.Context, resolver dnsclient.Resolver, name, qtype string, noCache bool) *dnsclient.ResolverResult {
 	cacheKey := cache.Key(resolver.ID, name, qtype)
 
-	if data, ok := c.cache.Get(ctx, cacheKey); ok {
-		c.m.cacheHits.Inc()
-		var result dnsclient.ResolverResult
-		if err := json.Unmarshal(data, &result); err == nil {
-			return &result
+	// noCache bypasses the cache entirely so each call is a fresh live query.
+	if !noCache {
+		if data, ok := c.cache.Get(ctx, cacheKey); ok {
+			c.m.cacheHits.Inc()
+			var result dnsclient.ResolverResult
+			if err := json.Unmarshal(data, &result); err == nil {
+				return &result
+			}
 		}
+		c.m.cacheMisses.Inc()
 	}
-	c.m.cacheMisses.Inc()
 
 	qtypeNum, _ := dnsclient.ParseType(qtype)
 	result, err := c.client.Query(ctx, resolver, name, qtypeNum)
@@ -294,8 +300,10 @@ func (c *Checker) queryWithCache(ctx context.Context, resolver dnsclient.Resolve
 		}
 	}
 
-	if data, err := json.Marshal(result); err == nil {
-		_ = c.cache.Set(ctx, cacheKey, data, c.cfg.Cache.TTL)
+	if !noCache {
+		if data, err := json.Marshal(result); err == nil {
+			_ = c.cache.Set(ctx, cacheKey, data, c.cfg.Cache.TTL)
+		}
 	}
 
 	return result

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -246,6 +246,28 @@ func TestCache_Integration(t *testing.T) {
 	assert.Equal(t, first, callCount)
 }
 
+func TestNoCache_AlwaysQueries(t *testing.T) {
+	res1 := dnsclient.Resolver{ID: "r1", Name: "R1", IP: "1.1.1.1", Port: 53}
+
+	callCount := 0
+	client := &countingClient{inner: &mockClient{}, callCount: &callCount}
+	mem, err := cache.NewMemory(100)
+	require.NoError(t, err)
+
+	reg := testRegistry([]dnsclient.Resolver{res1})
+	c := checker.New(client, reg, mem, &storage.Noop{}, testConfig())
+	ctx := context.Background()
+
+	_, err = c.Check(ctx, checker.CheckRequest{Name: "example.com", Type: "A", NoCache: true})
+	require.NoError(t, err)
+	first := callCount
+
+	// With NoCache the second check must query again, not serve from cache.
+	_, err = c.Check(ctx, checker.CheckRequest{Name: "example.com", Type: "A", NoCache: true})
+	require.NoError(t, err)
+	assert.Greater(t, callCount, first, "NoCache check should re-query, not use the cache")
+}
+
 type countingClient struct {
 	inner     dnsclient.Client
 	callCount *int

--- a/internal/checker/stream.go
+++ b/internal/checker/stream.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/t0mer/dnsmon/internal/cache"
 	"github.com/t0mer/dnsmon/internal/dnsclient"
 )
 
@@ -64,10 +63,7 @@ func (c *Checker) Stream(ctx context.Context, req StreamRequest) (<-chan *dnscli
 				sem <- struct{}{}
 				defer func() { <-sem }()
 
-				cacheKey := cache.Key(resolver.ID, req.Name, req.Type)
-				result := c.queryWithCache(ctx, resolver, req.Name, req.Type)
-
-				_ = cacheKey
+				result := c.queryWithCache(ctx, resolver, req.Name, req.Type, false)
 
 				c.m.queryTotal.WithLabelValues(resolver.ID, result.Status).Inc()
 				c.m.queryDuration.WithLabelValues(resolver.ID, result.Status).

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -18,7 +18,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("storage.dsn", "file:./dnsmon.db?cache=shared&_fk=1")
 	v.SetDefault("storage.retention_days", 30)
 
-	v.SetDefault("cache.driver", "memory")
+	v.SetDefault("cache.driver", "none")
 	v.SetDefault("cache.ttl", "60s")
 	v.SetDefault("cache.size", 10000)
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,213 @@
+// Package monitor evaluates monitors: it runs a propagation check for a
+// monitor's record, decides whether the record has propagated (propagation
+// monitors) or drifted from its baseline (change monitors), records a changelog
+// entry, and notifies the bound channel on an alert. The same Evaluator is used
+// by the manual "Run" action and (later) the scheduled engine.
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+// CheckRunner performs a propagation check. *checker.Checker satisfies it.
+type CheckRunner interface {
+	Check(ctx context.Context, req checker.CheckRequest) (*dnsclient.Check, error)
+}
+
+// Notifier delivers a message to a channel. *notify.Sender satisfies it.
+type Notifier interface {
+	Send(ctx context.Context, ch settings.NotificationChannel, message string) error
+}
+
+// Evaluator runs monitors.
+type Evaluator struct {
+	check    CheckRunner
+	store    storage.Storage
+	notifier Notifier
+}
+
+// New returns an Evaluator.
+func New(check CheckRunner, store storage.Storage, notifier Notifier) *Evaluator {
+	return &Evaluator{check: check, store: store, notifier: notifier}
+}
+
+// RunByID loads a monitor and evaluates it once.
+func (e *Evaluator) RunByID(ctx context.Context, id string) (*settings.MonitorEvent, error) {
+	m, err := e.store.GetMonitor(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return e.Run(ctx, m)
+}
+
+// Run evaluates a monitor once, records a changelog entry, re-baselines change
+// monitors after a change, and notifies the bound channel on an alert.
+func (e *Evaluator) Run(ctx context.Context, m *settings.Monitor) (*settings.MonitorEvent, error) {
+	ev := &settings.MonitorEvent{
+		ID:        settings.NewID(),
+		MonitorID: m.ID,
+		Timestamp: time.Now().UTC(),
+	}
+
+	check, err := e.check.Check(ctx, checker.CheckRequest{Name: m.FQDN, Type: m.RecordType, NoCache: true})
+	if err != nil {
+		ev.Status = settings.MonitorStatusError
+		ev.Message = "Check failed: " + err.Error()
+		_ = e.store.AppendMonitorEvent(ctx, ev)
+		return ev, nil
+	}
+
+	switch m.Type {
+	case settings.MonitorChange:
+		e.evaluateChange(ctx, m, check, ev)
+	default:
+		e.evaluatePropagation(ctx, m, check, ev)
+	}
+
+	_ = e.store.AppendMonitorEvent(ctx, ev)
+	return ev, nil
+}
+
+func (e *Evaluator) evaluateChange(ctx context.Context, m *settings.Monitor, check *dnsclient.Check, ev *settings.MonitorEvent) {
+	observed := consensus(check)
+	ev.Observed = observed
+
+	switch {
+	case len(m.Expected) == 0:
+		m.Expected = observed
+		m.UpdatedAt = time.Now().UTC()
+		_ = e.store.SaveMonitor(ctx, m)
+		ev.Status = settings.MonitorStatusOK
+		ev.Message = "Baseline captured: " + join(observed)
+	case !setEqual(observed, m.Expected):
+		old := m.Expected
+		ev.Status = settings.MonitorStatusChanged
+		ev.Message = "Changed: " + join(old) + " → " + join(observed)
+		// Re-baseline so each distinct change alerts once.
+		m.Expected = observed
+		m.UpdatedAt = time.Now().UTC()
+		_ = e.store.SaveMonitor(ctx, m)
+		ev.Notified = e.maybeNotify(ctx, m,
+			fmt.Sprintf("[dnsmon] %s: value changed from %s to %s", label(m), join(old), join(observed)))
+	default:
+		ev.Status = settings.MonitorStatusOK
+		ev.Message = "No change."
+	}
+}
+
+func (e *Evaluator) evaluatePropagation(ctx context.Context, m *settings.Monitor, check *dnsclient.Check, ev *settings.MonitorEvent) {
+	responded, matched := 0, 0
+	for _, r := range check.Results {
+		switch r.Status {
+		case dnsclient.StatusOK:
+			responded++
+			if setEqual(answerValues(r), m.Expected) {
+				matched++
+			}
+		case dnsclient.StatusNXDomain:
+			responded++
+		}
+	}
+	ev.Observed = consensus(check)
+
+	if responded > 0 && matched == responded {
+		ev.Status = settings.MonitorStatusOK
+		ev.Message = fmt.Sprintf("Propagated: all %d resolvers return the expected value.", responded)
+		return
+	}
+	ev.Status = settings.MonitorStatusNotPropagated
+	ev.Message = fmt.Sprintf("Not propagated: %d of %d resolvers match the expected value.", matched, responded)
+	ev.Notified = e.maybeNotify(ctx, m,
+		fmt.Sprintf("[dnsmon] %s: propagation incomplete — %d/%d resolvers match expected %s",
+			label(m), matched, responded, join(m.Expected)))
+}
+
+// maybeNotify sends to the monitor's bound channel if it exists and is enabled.
+func (e *Evaluator) maybeNotify(ctx context.Context, m *settings.Monitor, message string) bool {
+	if m.ChannelID == "" {
+		return false
+	}
+	s, err := e.store.GetSettings(ctx)
+	if err != nil {
+		return false
+	}
+	for _, c := range s.Notifications {
+		if c.ID == m.ChannelID && c.Enabled {
+			return e.notifier.Send(ctx, c, message) == nil
+		}
+	}
+	return false
+}
+
+func label(m *settings.Monitor) string {
+	name := m.Name
+	if name == "" {
+		name = m.FQDN
+	}
+	return fmt.Sprintf("%s (%s %s)", name, m.FQDN, m.RecordType)
+}
+
+func answerValues(r dnsclient.ResolverResult) []string {
+	vals := make([]string, 0, len(r.Answers))
+	for _, a := range r.Answers {
+		vals = append(vals, a.Value)
+	}
+	return vals
+}
+
+func normalize(vs []string) []string {
+	c := append([]string(nil), vs...)
+	sort.Strings(c)
+	return c
+}
+
+func setEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	na, nb := normalize(a), normalize(b)
+	for i := range na {
+		if na[i] != nb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// consensus returns the most common answer-value set among OK results.
+func consensus(check *dnsclient.Check) []string {
+	counts := map[string]int{}
+	repr := map[string][]string{}
+	for _, r := range check.Results {
+		if r.Status != dnsclient.StatusOK {
+			continue
+		}
+		vs := normalize(answerValues(r))
+		key := strings.Join(vs, ",")
+		counts[key]++
+		repr[key] = vs
+	}
+	best, bestN := "", 0
+	for k, n := range counts {
+		if n > bestN {
+			best, bestN = k, n
+		}
+	}
+	return repr[best]
+}
+
+func join(vs []string) string {
+	if len(vs) == 0 {
+		return "(empty)"
+	}
+	return strings.Join(vs, ", ")
+}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,136 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/t0mer/dnsmon/internal/checker"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+	"github.com/t0mer/dnsmon/internal/settings"
+	sqlitestore "github.com/t0mer/dnsmon/internal/storage/sqlite"
+)
+
+// fakeCheck returns a canned Check.
+type fakeCheck struct{ results []dnsclient.ResolverResult }
+
+func (f *fakeCheck) Check(_ context.Context, _ checker.CheckRequest) (*dnsclient.Check, error) {
+	return &dnsclient.Check{Results: f.results}, nil
+}
+
+// fakeNotifier records sends.
+type fakeNotifier struct{ sent []string }
+
+func (n *fakeNotifier) Send(_ context.Context, _ settings.NotificationChannel, msg string) error {
+	n.sent = append(n.sent, msg)
+	return nil
+}
+
+func okResult(id string, values ...string) dnsclient.ResolverResult {
+	ans := make([]dnsclient.Answer, len(values))
+	for i, v := range values {
+		ans[i] = dnsclient.Answer{Value: v, Type: "A"}
+	}
+	return dnsclient.ResolverResult{
+		Resolver: dnsclient.Resolver{ID: id},
+		Status:   dnsclient.StatusOK,
+		Answers:  ans,
+	}
+}
+
+func newStore(t *testing.T) *sqlitestore.Store {
+	t.Helper()
+	s, err := sqlitestore.New(context.Background(), "file:"+t.TempDir()+"/m.db?_fk=1")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestPropagation_AllMatch(t *testing.T) {
+	store := newStore(t)
+	notifier := &fakeNotifier{}
+	ev := New(&fakeCheck{results: []dnsclient.ResolverResult{okResult("r1", "1.2.3.4"), okResult("r2", "1.2.3.4")}}, store, notifier)
+
+	m := &settings.Monitor{ID: "m1", Type: settings.MonitorPropagation, FQDN: "x.com", RecordType: "A", Expected: []string{"1.2.3.4"}, ChannelID: "c1"}
+	e, _ := ev.Run(context.Background(), m)
+	if e.Status != settings.MonitorStatusOK {
+		t.Errorf("status = %q, want ok", e.Status)
+	}
+	if len(notifier.sent) != 0 {
+		t.Errorf("should not notify on full propagation, sent %v", notifier.sent)
+	}
+}
+
+func TestPropagation_PartialAlerts(t *testing.T) {
+	store := newStore(t)
+	// Bind an enabled channel via settings.
+	s := settings.Default()
+	s.Notifications = []settings.NotificationChannel{{ID: "c1", Type: settings.ChannelShoutrrr, Enabled: true, Config: map[string]string{"url": "x"}}}
+	_ = store.SaveSettings(context.Background(), s)
+
+	notifier := &fakeNotifier{}
+	ev := New(&fakeCheck{results: []dnsclient.ResolverResult{okResult("r1", "1.2.3.4"), okResult("r2", "9.9.9.9")}}, store, notifier)
+
+	m := &settings.Monitor{ID: "m1", Type: settings.MonitorPropagation, FQDN: "x.com", RecordType: "A", Expected: []string{"1.2.3.4"}, ChannelID: "c1"}
+	e, _ := ev.Run(context.Background(), m)
+	if e.Status != settings.MonitorStatusNotPropagated {
+		t.Errorf("status = %q, want not_propagated", e.Status)
+	}
+	if !e.Notified || len(notifier.sent) != 1 {
+		t.Errorf("expected one notification, got notified=%v sent=%v", e.Notified, notifier.sent)
+	}
+}
+
+func TestChange_BaselineThenChange(t *testing.T) {
+	store := newStore(t)
+	s := settings.Default()
+	s.Notifications = []settings.NotificationChannel{{ID: "c1", Type: settings.ChannelShoutrrr, Enabled: true, Config: map[string]string{"url": "x"}}}
+	_ = store.SaveSettings(context.Background(), s)
+	notifier := &fakeNotifier{}
+
+	m := &settings.Monitor{ID: "m1", Type: settings.MonitorChange, FQDN: "x.com", RecordType: "A", ChannelID: "c1"}
+	require := func(cond bool, msg string) {
+		if !cond {
+			t.Fatal(msg)
+		}
+	}
+	require(store.SaveMonitor(context.Background(), m) == nil, "save monitor")
+
+	// First run with empty baseline -> capture, no alert.
+	ev1 := New(&fakeCheck{results: []dnsclient.ResolverResult{okResult("r1", "1.1.1.1"), okResult("r2", "1.1.1.1")}}, store, notifier)
+	e, _ := ev1.Run(context.Background(), m)
+	if e.Status != settings.MonitorStatusOK || len(notifier.sent) != 0 {
+		t.Fatalf("baseline run: status=%q sent=%v", e.Status, notifier.sent)
+	}
+	if len(m.Expected) != 1 || m.Expected[0] != "1.1.1.1" {
+		t.Fatalf("baseline not captured: %v", m.Expected)
+	}
+
+	// Second run with a different value -> changed + alert + re-baseline.
+	ev2 := New(&fakeCheck{results: []dnsclient.ResolverResult{okResult("r1", "2.2.2.2"), okResult("r2", "2.2.2.2")}}, store, notifier)
+	e2, _ := ev2.Run(context.Background(), m)
+	if e2.Status != settings.MonitorStatusChanged {
+		t.Fatalf("expected changed, got %q", e2.Status)
+	}
+	if !e2.Notified || len(notifier.sent) != 1 {
+		t.Fatalf("expected one alert, got notified=%v sent=%v", e2.Notified, notifier.sent)
+	}
+	if m.Expected[0] != "2.2.2.2" {
+		t.Fatalf("expected re-baseline to 2.2.2.2, got %v", m.Expected)
+	}
+
+	// Third run, same as new baseline -> no change.
+	e3, _ := ev2.Run(context.Background(), m)
+	if e3.Status != settings.MonitorStatusOK || len(notifier.sent) != 1 {
+		t.Fatalf("expected no new alert, got status=%q sent=%v", e3.Status, notifier.sent)
+	}
+
+	// History should have accumulated events.
+	events, _ := store.ListMonitorEvents(context.Background(), "m1", 10)
+	if len(events) < 3 {
+		t.Errorf("expected >=3 history events, got %d", len(events))
+	}
+	_ = time.Now
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -66,6 +66,55 @@ type Schedule struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// Monitor type identifiers.
+const (
+	// MonitorPropagation alerts when a record has not propagated to the expected
+	// value across resolvers.
+	MonitorPropagation = "propagation"
+	// MonitorChange alerts when a record's value drifts from a stored baseline.
+	MonitorChange = "change"
+)
+
+// Monitor event statuses recorded in the changelog.
+const (
+	MonitorStatusCreated       = "created"
+	MonitorStatusOK            = "ok"             // propagated / unchanged
+	MonitorStatusNotPropagated = "not_propagated" // propagation monitor: expected value missing somewhere
+	MonitorStatusChanged       = "changed"        // change monitor: value drifted from baseline
+	MonitorStatusError         = "error"
+)
+
+// Monitor watches a record and notifies on a propagation failure or an
+// unexpected change. It runs whenever its bound Schedule fires (execution is
+// implemented in a later change).
+type Monitor struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Type       string   `json:"type"` // MonitorPropagation | MonitorChange
+	FQDN       string   `json:"fqdn"`
+	RecordType string   `json:"record_type"`
+	// Expected holds the values the record should resolve to: the required
+	// values for a propagation monitor, or the current baseline for a change
+	// monitor (updated to the new value after an alert).
+	Expected    []string  `json:"expected"`
+	SchedulerID string    `json:"scheduler_id"`
+	ChannelID   string    `json:"channel_id"`
+	Enabled     bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// MonitorEvent is a single entry in a monitor's changelog.
+type MonitorEvent struct {
+	ID        string    `json:"id"`
+	MonitorID string    `json:"monitor_id"`
+	Timestamp time.Time `json:"timestamp"`
+	Status    string    `json:"status"`
+	Observed  []string  `json:"observed"`
+	Message   string    `json:"message"`
+	Notified  bool      `json:"notified"`
+}
+
 // Default returns an empty Settings with sensible zero values.
 func Default() *Settings {
 	return &Settings{

--- a/internal/storage/postgres/migrations/0003_monitors.sql
+++ b/internal/storage/postgres/migrations/0003_monitors.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS monitors (
+    id TEXT PRIMARY KEY,
+    data BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_monitors_created_at ON monitors(created_at);
+
+CREATE TABLE IF NOT EXISTS monitor_events (
+    id TEXT PRIMARY KEY,
+    monitor_id TEXT NOT NULL,
+    ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    data BYTEA NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_monitor_events_monitor ON monitor_events(monitor_id, ts);

--- a/internal/storage/postgres/monitors.go
+++ b/internal/storage/postgres/monitors.go
@@ -1,0 +1,122 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+// ListMonitors returns all monitors ordered by creation time.
+func (s *Store) ListMonitors(ctx context.Context) ([]*settings.Monitor, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT data FROM monitors ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying monitors: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*settings.Monitor
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("scanning monitor row: %w", err)
+		}
+		var m settings.Monitor
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("unmarshaling monitor: %w", err)
+		}
+		out = append(out, &m)
+	}
+	return out, rows.Err()
+}
+
+// GetMonitor returns a single monitor by ID.
+func (s *Store) GetMonitor(ctx context.Context, id string) (*settings.Monitor, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT data FROM monitors WHERE id = $1`, id)
+	var data []byte
+	if err := row.Scan(&data); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning monitor row: %w", err)
+	}
+	var m settings.Monitor
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("unmarshaling monitor: %w", err)
+	}
+	return &m, nil
+}
+
+// SaveMonitor upserts a monitor.
+func (s *Store) SaveMonitor(ctx context.Context, m *settings.Monitor) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling monitor: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO monitors (id, data, created_at, updated_at) VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
+		m.ID, data, m.CreatedAt, m.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("saving monitor: %w", err)
+	}
+	return nil
+}
+
+// DeleteMonitor removes a monitor and its events.
+func (s *Store) DeleteMonitor(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM monitors WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("deleting monitor: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return storage.ErrNotFound
+	}
+	_, _ = s.db.ExecContext(ctx, `DELETE FROM monitor_events WHERE monitor_id = $1`, id)
+	return nil
+}
+
+// ListMonitorEvents returns a monitor's changelog, most recent first.
+func (s *Store) ListMonitorEvents(ctx context.Context, monitorID string, limit int) ([]*settings.MonitorEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT data FROM monitor_events WHERE monitor_id = $1 ORDER BY ts DESC LIMIT $2`, monitorID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying monitor events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*settings.MonitorEvent
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("scanning monitor event row: %w", err)
+		}
+		var e settings.MonitorEvent
+		if err := json.Unmarshal(data, &e); err != nil {
+			return nil, fmt.Errorf("unmarshaling monitor event: %w", err)
+		}
+		out = append(out, &e)
+	}
+	return out, rows.Err()
+}
+
+// AppendMonitorEvent records a changelog entry.
+func (s *Store) AppendMonitorEvent(ctx context.Context, e *settings.MonitorEvent) error {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshaling monitor event: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO monitor_events (id, monitor_id, ts, data) VALUES ($1, $2, $3, $4)`,
+		e.ID, e.MonitorID, e.Timestamp, data)
+	if err != nil {
+		return fmt.Errorf("appending monitor event: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/sqlite/migrations/0003_monitors.sql
+++ b/internal/storage/sqlite/migrations/0003_monitors.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS monitors (
+    id TEXT PRIMARY KEY,
+    data BLOB NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_monitors_created_at ON monitors(created_at);
+
+CREATE TABLE IF NOT EXISTS monitor_events (
+    id TEXT PRIMARY KEY,
+    monitor_id TEXT NOT NULL,
+    ts DATETIME NOT NULL DEFAULT (datetime('now')),
+    data BLOB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_monitor_events_monitor ON monitor_events(monitor_id, ts);

--- a/internal/storage/sqlite/monitors.go
+++ b/internal/storage/sqlite/monitors.go
@@ -1,0 +1,123 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/t0mer/dnsmon/internal/settings"
+	"github.com/t0mer/dnsmon/internal/storage"
+)
+
+// ListMonitors returns all monitors ordered by creation time.
+func (s *Store) ListMonitors(ctx context.Context) ([]*settings.Monitor, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT data FROM monitors ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying monitors: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*settings.Monitor
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("scanning monitor row: %w", err)
+		}
+		var m settings.Monitor
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("unmarshaling monitor: %w", err)
+		}
+		out = append(out, &m)
+	}
+	return out, rows.Err()
+}
+
+// GetMonitor returns a single monitor by ID.
+func (s *Store) GetMonitor(ctx context.Context, id string) (*settings.Monitor, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT data FROM monitors WHERE id = ?`, id)
+	var data []byte
+	if err := row.Scan(&data); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning monitor row: %w", err)
+	}
+	var m settings.Monitor
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("unmarshaling monitor: %w", err)
+	}
+	return &m, nil
+}
+
+// SaveMonitor upserts a monitor.
+func (s *Store) SaveMonitor(ctx context.Context, m *settings.Monitor) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling monitor: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO monitors (id, data, created_at, updated_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at`,
+		m.ID, data, m.CreatedAt.UTC().Format(time.RFC3339), m.UpdatedAt.UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("saving monitor: %w", err)
+	}
+	return nil
+}
+
+// DeleteMonitor removes a monitor and its events.
+func (s *Store) DeleteMonitor(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM monitors WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting monitor: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return storage.ErrNotFound
+	}
+	_, _ = s.db.ExecContext(ctx, `DELETE FROM monitor_events WHERE monitor_id = ?`, id)
+	return nil
+}
+
+// ListMonitorEvents returns a monitor's changelog, most recent first.
+func (s *Store) ListMonitorEvents(ctx context.Context, monitorID string, limit int) ([]*settings.MonitorEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT data FROM monitor_events WHERE monitor_id = ? ORDER BY ts DESC LIMIT ?`, monitorID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying monitor events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*settings.MonitorEvent
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("scanning monitor event row: %w", err)
+		}
+		var e settings.MonitorEvent
+		if err := json.Unmarshal(data, &e); err != nil {
+			return nil, fmt.Errorf("unmarshaling monitor event: %w", err)
+		}
+		out = append(out, &e)
+	}
+	return out, rows.Err()
+}
+
+// AppendMonitorEvent records a changelog entry.
+func (s *Store) AppendMonitorEvent(ctx context.Context, e *settings.MonitorEvent) error {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshaling monitor event: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO monitor_events (id, monitor_id, ts, data) VALUES (?, ?, ?, ?)`,
+		e.ID, e.MonitorID, e.Timestamp.UTC().Format(time.RFC3339), data)
+	if err != nil {
+		return fmt.Errorf("appending monitor event: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/sqlite/settings_test.go
+++ b/internal/storage/sqlite/settings_test.go
@@ -76,6 +76,60 @@ func TestAPITokenCRUD(t *testing.T) {
 	}
 }
 
+func TestMonitorCRUDAndEvents(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	now := time.Now().UTC()
+	m := &settings.Monitor{
+		ID: "m1", Name: "watch", Type: settings.MonitorPropagation,
+		FQDN: "example.com", RecordType: "A", Expected: []string{"1.2.3.4"},
+		SchedulerID: "sch1", ChannelID: "ch1", Enabled: true,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.SaveMonitor(ctx, m); err != nil {
+		t.Fatalf("SaveMonitor: %v", err)
+	}
+
+	got, err := s.GetMonitor(ctx, "m1")
+	if err != nil || got.FQDN != "example.com" || len(got.Expected) != 1 {
+		t.Fatalf("GetMonitor = %+v, err %v", got, err)
+	}
+
+	// Update (upsert).
+	m.Name = "renamed"
+	m.UpdatedAt = now.Add(time.Minute)
+	if err := s.SaveMonitor(ctx, m); err != nil {
+		t.Fatalf("SaveMonitor update: %v", err)
+	}
+	list, err := s.ListMonitors(ctx)
+	if err != nil || len(list) != 1 || list[0].Name != "renamed" {
+		t.Fatalf("ListMonitors = %+v, err %v", list, err)
+	}
+
+	// Events.
+	ev := &settings.MonitorEvent{ID: "e1", MonitorID: "m1", Timestamp: now,
+		Status: settings.MonitorStatusCreated, Observed: []string{"1.2.3.4"}, Message: "created"}
+	if err := s.AppendMonitorEvent(ctx, ev); err != nil {
+		t.Fatalf("AppendMonitorEvent: %v", err)
+	}
+	events, err := s.ListMonitorEvents(ctx, "m1", 10)
+	if err != nil || len(events) != 1 || events[0].Status != settings.MonitorStatusCreated {
+		t.Fatalf("ListMonitorEvents = %+v, err %v", events, err)
+	}
+
+	// Delete cascades events.
+	if err := s.DeleteMonitor(ctx, "m1"); err != nil {
+		t.Fatalf("DeleteMonitor: %v", err)
+	}
+	if list, _ := s.ListMonitors(ctx); len(list) != 0 {
+		t.Errorf("expected no monitors after delete, got %d", len(list))
+	}
+	if events, _ := s.ListMonitorEvents(ctx, "m1", 10); len(events) != 0 {
+		t.Errorf("expected no events after delete, got %d", len(events))
+	}
+}
+
 func TestScheduleCRUD(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -33,6 +33,14 @@ type Storage interface {
 	SaveSchedule(ctx context.Context, s *settings.Schedule) error
 	DeleteSchedule(ctx context.Context, id string) error
 
+	// Monitors and their changelog.
+	ListMonitors(ctx context.Context) ([]*settings.Monitor, error)
+	GetMonitor(ctx context.Context, id string) (*settings.Monitor, error)
+	SaveMonitor(ctx context.Context, m *settings.Monitor) error
+	DeleteMonitor(ctx context.Context, id string) error
+	ListMonitorEvents(ctx context.Context, monitorID string, limit int) ([]*settings.MonitorEvent, error)
+	AppendMonitorEvent(ctx context.Context, e *settings.MonitorEvent) error
+
 	Close() error
 }
 
@@ -70,5 +78,21 @@ func (n *Noop) ListSchedules(_ context.Context) ([]*settings.Schedule, error) { 
 func (n *Noop) SaveSchedule(_ context.Context, _ *settings.Schedule) error { return nil }
 
 func (n *Noop) DeleteSchedule(_ context.Context, _ string) error { return nil }
+
+func (n *Noop) ListMonitors(_ context.Context) ([]*settings.Monitor, error) { return nil, nil }
+
+func (n *Noop) GetMonitor(_ context.Context, _ string) (*settings.Monitor, error) {
+	return nil, ErrNotFound
+}
+
+func (n *Noop) SaveMonitor(_ context.Context, _ *settings.Monitor) error { return nil }
+
+func (n *Noop) DeleteMonitor(_ context.Context, _ string) error { return nil }
+
+func (n *Noop) ListMonitorEvents(_ context.Context, _ string, _ int) ([]*settings.MonitorEvent, error) {
+	return nil, nil
+}
+
+func (n *Noop) AppendMonitorEvent(_ context.Context, _ *settings.MonitorEvent) error { return nil }
 
 func (n *Noop) Close() error { return nil }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -174,6 +174,29 @@
                   </template>
                 </div>
               </div>
+
+              <div x-show="results.length > 0" class="relative" x-data="{ monitorOpen: false }">
+                <button type="button" @click="monitorOpen = !monitorOpen"
+                  class="btn bg-white/10 hover:bg-white/20 text-white ring-1 ring-white/20"
+                  :aria-expanded="monitorOpen" aria-label="Create a monitor from this check">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+                  Create monitor
+                  <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+                </button>
+                <div x-show="monitorOpen" @click.outside="monitorOpen = false" x-transition
+                  class="absolute right-0 top-full mt-1.5 w-64 card py-1 z-20 shadow-xl" role="menu">
+                  <button type="button" @click="createMonitor('propagation'); monitorOpen = false"
+                    class="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800" role="menuitem">
+                    <div class="font-medium">Propagation monitor</div>
+                    <div class="text-xs text-slate-400">Alert if these values don't propagate</div>
+                  </button>
+                  <button type="button" @click="createMonitor('change'); monitorOpen = false"
+                    class="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800" role="menuitem">
+                    <div class="font-medium">Change-detection monitor</div>
+                    <div class="text-xs text-slate-400">Alert if these values change later</div>
+                  </button>
+                </div>
+              </div>
             </div>
 
           </form>

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -546,10 +546,6 @@ function settingsApp() {
     monitorForm: { type: 'propagation', name: '', fqdn: '', record_type: 'A', expected: '', scheduler_id: '', channel_id: '', enabled: true },
     monitorEditId: '',
     showMonitorEditor: false,
-    newSchedulerOpen: false,
-    newSchedulerForm: { name: '', cadence: '@daily', cron: '' },
-    newChannelOpen: false,
-    newChannelForm: { type: 'shoutrrr', name: '', config: { url: '' } },
     historyMonitorId: '',
     historyEvents: [],
 
@@ -867,8 +863,6 @@ function settingsApp() {
     openAddMonitor() {
       this.monitorEditId = '';
       this.monitorForm = { type: 'propagation', name: '', fqdn: '', record_type: 'A', expected: '', scheduler_id: '', channel_id: '', enabled: true };
-      this.newSchedulerOpen = false;
-      this.newChannelOpen = false;
       this.showMonitorEditor = true;
     },
     openEditMonitor(m) {
@@ -883,8 +877,6 @@ function settingsApp() {
         channel_id: m.channel_id || '',
         enabled: m.enabled,
       };
-      this.newSchedulerOpen = false;
-      this.newChannelOpen = false;
       this.showMonitorEditor = true;
     },
     cancelMonitorEditor() {
@@ -940,6 +932,25 @@ function settingsApp() {
         this.flash('Failed to delete monitor', true);
       }
     },
+    async refreshMonitors() {
+      const resp = await fetch('/api/v1/settings/monitors');
+      if (resp.ok) this.monitors = await resp.json();
+    },
+    // Evaluate a monitor on demand and surface the result.
+    async runMonitor(id) {
+      const resp = await fetch('/api/v1/settings/monitors/' + id + '/run', { method: 'POST' });
+      if (this.unauthorized(resp)) return;
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        this.flash(e?.error?.message || 'Run failed', true);
+        return;
+      }
+      const ev = await resp.json();
+      const isAlert = ev.status === 'not_propagated' || ev.status === 'changed' || ev.status === 'error';
+      this.flash(`${ev.status}: ${ev.message}${ev.notified ? ' (notified)' : ''}`, isAlert);
+      await this.refreshMonitors();
+      if (this.historyMonitorId === id) await this.viewHistory(id);
+    },
     async viewHistory(id) {
       const resp = await fetch('/api/v1/settings/monitors/' + id + '/history');
       if (!resp.ok) { this.flash('Failed to load history', true); return; }
@@ -949,45 +960,6 @@ function settingsApp() {
     closeHistory() {
       this.historyMonitorId = '';
       this.historyEvents = [];
-    },
-
-    // Inline create of a scheduler from the monitor form.
-    async createInlineScheduler() {
-      const f = this.newSchedulerForm;
-      const cron = f.cadence === 'custom' ? f.cron.trim() : f.cadence;
-      if (!f.name.trim() || !cron) return;
-      const resp = await fetch('/api/v1/settings/schedules', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: f.name.trim(), cron, enabled: true }),
-      });
-      if (!resp.ok) { this.flash('Failed to create scheduler', true); return; }
-      const sc = await resp.json();
-      this.schedules.unshift(sc);
-      this.monitorForm.scheduler_id = sc.id;
-      this.newSchedulerForm = { name: '', cadence: '@daily', cron: '' };
-      this.newSchedulerOpen = false;
-      this.flash('Scheduler created.');
-    },
-
-    // Inline create of a notification channel from the monitor form.
-    channelDefaultsFor(type) {
-      return this.channelDefaults(type);
-    },
-    onNewChannelType() {
-      this.newChannelForm.config = this.channelDefaults(this.newChannelForm.type);
-    },
-    async createInlineChannel() {
-      const f = this.newChannelForm;
-      if (!f.name.trim()) { this.flash('Channel name is required.', true); return; }
-      // Channels persist as part of the settings document; append + save.
-      this.notifications.push({ id: '', type: f.type, name: f.name.trim(), enabled: true, config: { ...f.config } });
-      await this.saveSettings();
-      const created = this.notifications.find((c) => c.name === f.name.trim() && c.type === f.type && c.id);
-      if (created) this.monitorForm.channel_id = created.id;
-      this.newChannelForm = { type: 'shoutrrr', name: '', config: { url: '' } };
-      this.newChannelOpen = false;
-      this.flash('Channel created.');
     },
 
     // ---- Resolver enable/disable ----

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -261,6 +261,30 @@ function dnsmonApp() {
       });
     },
 
+    // Hand off the current check to the Settings → Monitors tab, prefilling the
+    // FQDN, record type, and the majority answer set (as expected / baseline).
+    createMonitor(monitorType) {
+      if (this.results.length === 0) return;
+      let expected = [];
+      if (this.summary && this.summary.consensus) {
+        let best = '';
+        let bestN = -1;
+        for (const [k, n] of Object.entries(this.summary.consensus)) {
+          if (n > bestN) { bestN = n; best = k; }
+        }
+        if (best && best !== '<empty>') {
+          expected = best.split(',').map((s) => s.trim()).filter(Boolean);
+        }
+      }
+      sessionStorage.setItem('dnsmon.newMonitor', JSON.stringify({
+        type: monitorType,
+        fqdn: this.domain.trim(),
+        record_type: this.type,
+        expected,
+      }));
+      window.location.href = '/settings?tab=monitors';
+    },
+
     // ---------------------------------------------------------------------------
     // Sorting
     // ---------------------------------------------------------------------------
@@ -517,11 +541,41 @@ function settingsApp() {
     resolvers: [],
     resolverQuery: '',
 
+    // Monitors
+    monitors: [],
+    monitorForm: { type: 'propagation', name: '', fqdn: '', record_type: 'A', expected: '', scheduler_id: '', channel_id: '', enabled: true },
+    monitorEditId: '',
+    showMonitorEditor: false,
+    newSchedulerOpen: false,
+    newSchedulerForm: { name: '', cadence: '@daily', cron: '' },
+    newChannelOpen: false,
+    newChannelForm: { type: 'shoutrrr', name: '', config: { url: '' } },
+    historyMonitorId: '',
+    historyEvents: [],
+
     // Session
     currentUser: '',
 
     async init() {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('tab')) this.activeTab = params.get('tab');
       await this.loadAll();
+
+      // Prefill the monitor form from a "Create monitor" handoff (home page).
+      const pending = sessionStorage.getItem('dnsmon.newMonitor');
+      if (pending) {
+        sessionStorage.removeItem('dnsmon.newMonitor');
+        try {
+          const d = JSON.parse(pending);
+          this.activeTab = 'monitors';
+          this.openAddMonitor();
+          this.monitorForm.type = d.type || 'propagation';
+          this.monitorForm.fqdn = d.fqdn || '';
+          this.monitorForm.name = d.fqdn || '';
+          this.monitorForm.record_type = d.record_type || 'A';
+          this.monitorForm.expected = (d.expected || []).join('\n');
+        } catch { /* ignore malformed handoff */ }
+      }
     },
 
     // unauthorized() returns true (and redirects to /login) if the response is a 401.
@@ -544,9 +598,10 @@ function settingsApp() {
           fetch('/api/v1/settings/tokens'),
           fetch('/api/v1/settings/schedules'),
           fetch('/api/v1/resolvers'),
+          fetch('/api/v1/settings/monitors'),
         ]);
         if (responses.some((r) => this.unauthorized(r))) return;
-        const [s, tk, sc, rs] = await Promise.all(responses.map((r) => r.json()));
+        const [s, tk, sc, rs, mon] = await Promise.all(responses.map((r) => r.json()));
         this.auth = {
           enabled: !!s.auth.enabled,
           username: s.auth.username || '',
@@ -558,6 +613,7 @@ function settingsApp() {
         this.tokens = tk || [];
         this.schedules = sc || [];
         this.resolvers = rs || [];
+        this.monitors = mon || [];
       } catch (e) {
         this.flash('Failed to load settings: ' + e.message, true);
       } finally {
@@ -794,6 +850,144 @@ function settingsApp() {
       } else {
         this.flash('Failed to delete scheduler', true);
       }
+    },
+
+    // ---- Monitors ----
+    monitorTypeLabel(type) {
+      return { propagation: 'Propagation', change: 'Change detection' }[type] || type;
+    },
+    schedulerName(id) {
+      const s = this.schedules.find((x) => x.id === id);
+      return s ? s.name : '—';
+    },
+    channelName(id) {
+      const c = this.notifications.find((x) => x.id === id);
+      return c ? c.name : '—';
+    },
+    openAddMonitor() {
+      this.monitorEditId = '';
+      this.monitorForm = { type: 'propagation', name: '', fqdn: '', record_type: 'A', expected: '', scheduler_id: '', channel_id: '', enabled: true };
+      this.newSchedulerOpen = false;
+      this.newChannelOpen = false;
+      this.showMonitorEditor = true;
+    },
+    openEditMonitor(m) {
+      this.monitorEditId = m.id;
+      this.monitorForm = {
+        type: m.type,
+        name: m.name || '',
+        fqdn: m.fqdn,
+        record_type: m.record_type,
+        expected: (m.expected || []).join('\n'),
+        scheduler_id: m.scheduler_id || '',
+        channel_id: m.channel_id || '',
+        enabled: m.enabled,
+      };
+      this.newSchedulerOpen = false;
+      this.newChannelOpen = false;
+      this.showMonitorEditor = true;
+    },
+    cancelMonitorEditor() {
+      this.showMonitorEditor = false;
+    },
+    async saveMonitor() {
+      const f = this.monitorForm;
+      if (!f.fqdn.trim()) { this.flash('FQDN is required.', true); return; }
+      const expected = f.expected.split(/[\n,]+/).map((v) => v.trim()).filter(Boolean);
+      if (f.type === 'propagation' && expected.length === 0) {
+        this.flash('Propagation monitors need at least one expected value.', true);
+        return;
+      }
+      const editing = this.monitorEditId !== '';
+      const url = editing ? '/api/v1/settings/monitors/' + this.monitorEditId : '/api/v1/settings/monitors';
+      const resp = await fetch(url, {
+        method: editing ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: f.type,
+          name: f.name.trim(),
+          fqdn: f.fqdn.trim(),
+          record_type: f.record_type,
+          expected,
+          scheduler_id: f.scheduler_id,
+          channel_id: f.channel_id,
+          enabled: f.enabled,
+        }),
+      });
+      if (this.unauthorized(resp)) return;
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        this.flash(e?.error?.message || 'Failed to save monitor', true);
+        return;
+      }
+      const m = await resp.json();
+      if (editing) {
+        const i = this.monitors.findIndex((x) => x.id === m.id);
+        if (i !== -1) this.monitors[i] = m;
+        this.flash('Monitor updated.');
+      } else {
+        this.monitors.unshift(m);
+        this.flash('Monitor created.');
+      }
+      this.showMonitorEditor = false;
+    },
+    async deleteMonitor(id) {
+      const resp = await fetch('/api/v1/settings/monitors/' + id, { method: 'DELETE' });
+      if (resp.ok || resp.status === 204) {
+        this.monitors = this.monitors.filter((m) => m.id !== id);
+        this.flash('Monitor deleted.');
+      } else {
+        this.flash('Failed to delete monitor', true);
+      }
+    },
+    async viewHistory(id) {
+      const resp = await fetch('/api/v1/settings/monitors/' + id + '/history');
+      if (!resp.ok) { this.flash('Failed to load history', true); return; }
+      this.historyEvents = await resp.json();
+      this.historyMonitorId = id;
+    },
+    closeHistory() {
+      this.historyMonitorId = '';
+      this.historyEvents = [];
+    },
+
+    // Inline create of a scheduler from the monitor form.
+    async createInlineScheduler() {
+      const f = this.newSchedulerForm;
+      const cron = f.cadence === 'custom' ? f.cron.trim() : f.cadence;
+      if (!f.name.trim() || !cron) return;
+      const resp = await fetch('/api/v1/settings/schedules', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: f.name.trim(), cron, enabled: true }),
+      });
+      if (!resp.ok) { this.flash('Failed to create scheduler', true); return; }
+      const sc = await resp.json();
+      this.schedules.unshift(sc);
+      this.monitorForm.scheduler_id = sc.id;
+      this.newSchedulerForm = { name: '', cadence: '@daily', cron: '' };
+      this.newSchedulerOpen = false;
+      this.flash('Scheduler created.');
+    },
+
+    // Inline create of a notification channel from the monitor form.
+    channelDefaultsFor(type) {
+      return this.channelDefaults(type);
+    },
+    onNewChannelType() {
+      this.newChannelForm.config = this.channelDefaults(this.newChannelForm.type);
+    },
+    async createInlineChannel() {
+      const f = this.newChannelForm;
+      if (!f.name.trim()) { this.flash('Channel name is required.', true); return; }
+      // Channels persist as part of the settings document; append + save.
+      this.notifications.push({ id: '', type: f.type, name: f.name.trim(), enabled: true, config: { ...f.config } });
+      await this.saveSettings();
+      const created = this.notifications.find((c) => c.name === f.name.trim() && c.type === f.type && c.id);
+      if (created) this.monitorForm.channel_id = created.id;
+      this.newChannelForm = { type: 'shoutrrr', name: '', config: { url: '' } };
+      this.newChannelOpen = false;
+      this.flash('Channel created.');
     },
 
     // ---- Resolver enable/disable ----

--- a/web/src/settings.html
+++ b/web/src/settings.html
@@ -390,70 +390,25 @@
           <!-- Scheduler binding -->
           <div>
             <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Schedule</label>
-            <div class="flex items-center gap-2">
-              <select x-model="monitorForm.scheduler_id" class="input">
-                <option value="">— none —</option>
-                <template x-for="s in schedules" :key="s.id">
-                  <option :value="s.id" x-text="s.name + ' (' + s.cron + ')'"></option>
-                </template>
-              </select>
-              <button type="button" @click="newSchedulerOpen = !newSchedulerOpen" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 whitespace-nowrap">+ New</button>
-            </div>
-            <div x-show="newSchedulerOpen" class="mt-2 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/40 flex flex-wrap items-end gap-2">
-              <div class="flex-1 min-w-[8rem]">
-                <label class="block text-xs text-slate-500 mb-1">Name</label>
-                <input type="text" x-model="newSchedulerForm.name" class="input-sm" placeholder="Hourly checks" />
-              </div>
-              <div>
-                <label class="block text-xs text-slate-500 mb-1">Cadence</label>
-                <select x-model="newSchedulerForm.cadence" class="input-sm">
-                  <option value="@hourly">Hourly</option>
-                  <option value="@daily">Daily</option>
-                  <option value="@weekly">Weekly</option>
-                  <option value="@monthly">Monthly</option>
-                  <option value="custom">Custom</option>
-                </select>
-              </div>
-              <input x-show="newSchedulerForm.cadence === 'custom'" type="text" x-model="newSchedulerForm.cron" class="input-sm font-mono" placeholder="*/15 * * * *" />
-              <button type="button" @click="createInlineScheduler()" class="btn-sm bg-indigo-600 text-white">Create</button>
-            </div>
+            <select x-model="monitorForm.scheduler_id" class="input">
+              <option value="">— none —</option>
+              <template x-for="s in schedules" :key="s.id">
+                <option :value="s.id" x-text="s.name + ' (' + s.cron + ')'"></option>
+              </template>
+            </select>
+            <p x-show="schedules.length === 0" class="text-xs text-slate-400 dark:text-slate-500 mt-1">No schedulers yet — create one in the Schedulers tab.</p>
           </div>
 
           <!-- Channel binding -->
           <div>
             <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Notification channel</label>
-            <div class="flex items-center gap-2">
-              <select x-model="monitorForm.channel_id" class="input">
-                <option value="">— none —</option>
-                <template x-for="c in notifications" :key="c.id">
-                  <option :value="c.id" x-text="(c.name || '(unnamed)') + ' · ' + channelTypeLabel(c.type)"></option>
-                </template>
-              </select>
-              <button type="button" @click="newChannelOpen = !newChannelOpen" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 whitespace-nowrap">+ New</button>
-            </div>
-            <div x-show="newChannelOpen" class="mt-2 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/40 space-y-2">
-              <div class="grid sm:grid-cols-2 gap-2">
-                <div>
-                  <label class="block text-xs text-slate-500 mb-1">Type</label>
-                  <select x-model="newChannelForm.type" @change="onNewChannelType()" class="input-sm">
-                    <option value="shoutrrr">Shoutrrr</option>
-                    <option value="greenapi">WhatsApp (GreenAPI)</option>
-                    <option value="gowa">WhatsApp (go-whatsapp-web)</option>
-                  </select>
-                </div>
-                <div>
-                  <label class="block text-xs text-slate-500 mb-1">Name</label>
-                  <input type="text" x-model="newChannelForm.name" class="input-sm" placeholder="Ops alerts" />
-                </div>
-              </div>
-              <template x-for="field in channelFields(newChannelForm.type)" :key="field">
-                <div>
-                  <label class="block text-xs text-slate-500 mb-1" x-text="fieldLabel(field)"></label>
-                  <input :type="field.includes('password') || field === 'token' ? 'password' : 'text'" x-model="newChannelForm.config[field]" class="input-sm font-mono" autocomplete="off" />
-                </div>
+            <select x-model="monitorForm.channel_id" class="input">
+              <option value="">— none —</option>
+              <template x-for="c in notifications" :key="c.id">
+                <option :value="c.id" x-text="(c.name || '(unnamed)') + ' · ' + channelTypeLabel(c.type)"></option>
               </template>
-              <button type="button" @click="createInlineChannel()" class="btn-sm bg-indigo-600 text-white">Create</button>
-            </div>
+            </select>
+            <p x-show="notifications.length === 0" class="text-xs text-slate-400 dark:text-slate-500 mt-1">No channels yet — create one in the Notifications tab.</p>
           </div>
 
           <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
@@ -493,6 +448,7 @@
                   <td class="px-4 py-2.5 text-xs text-slate-500" x-text="channelName(m.channel_id)"></td>
                   <td class="px-4 py-2.5"><span :class="m.enabled ? 'badge-ok' : 'badge-error'" x-text="m.enabled ? 'Enabled' : 'Disabled'"></span></td>
                   <td class="px-4 py-2.5 text-right whitespace-nowrap">
+                    <button @click="runMonitor(m.id)" class="btn-sm bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-950/60">Run</button>
                     <button @click="viewHistory(m.id)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">History</button>
                     <button @click="openEditMonitor(m)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Edit</button>
                     <button @click="deleteMonitor(m.id)" class="btn-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30">Delete</button>

--- a/web/src/settings.html
+++ b/web/src/settings.html
@@ -73,6 +73,7 @@
         {k:'tokens', l:'API Tokens'},
         {k:'resolvers', l:'Resolvers'},
         {k:'schedules', l:'Schedulers'},
+        {k:'monitors', l:'Monitors'},
       ]" :key="tab.k">
         <button @click="activeTab = tab.k"
           class="px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors"
@@ -332,6 +333,202 @@
           </table>
         </div>
         <p class="text-xs text-slate-400 dark:text-slate-500">Schedule execution and attaching monitors are added in a later release; this manages the schedule definitions.</p>
+      </section>
+
+      <!-- ============ MONITORS ============ -->
+      <section x-show="activeTab === 'monitors'" class="space-y-4">
+        <div class="flex items-center justify-between">
+          <h2 class="font-semibold text-slate-900 dark:text-white text-sm">Monitors</h2>
+          <button @click="openAddMonitor()" x-show="!showMonitorEditor" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+            Add
+          </button>
+        </div>
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          Watch a record and get notified on a propagation failure or an unexpected change. Each monitor runs on its bound schedule (execution is added in a later release).
+        </p>
+
+        <!-- Add / edit monitor editor -->
+        <div x-show="showMonitorEditor" class="card card-body space-y-3">
+          <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-300" x-text="monitorEditId ? 'Edit monitor' : 'Add monitor'"></h3>
+
+          <div class="grid sm:grid-cols-2 gap-3">
+            <div>
+              <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Monitor type</label>
+              <select x-model="monitorForm.type" class="input">
+                <option value="propagation">Propagation monitoring</option>
+                <option value="change">Change detection</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Name</label>
+              <input type="text" x-model="monitorForm.name" class="input" placeholder="defaults to the FQDN" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">FQDN</label>
+              <input type="text" x-model="monitorForm.fqdn" class="input" placeholder="example.com" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Record type</label>
+              <select x-model="monitorForm.record_type" class="input">
+                <template x-for="t in ['A','AAAA','CNAME','MX','NS','TXT','CAA','SRV','SOA','PTR']" :key="t">
+                  <option x-text="t"></option>
+                </template>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+              <span x-text="monitorForm.type === 'propagation' ? 'Expected value(s)' : 'Baseline value(s)'"></span>
+              <span class="text-slate-400">— one per line</span>
+            </label>
+            <textarea x-model="monitorForm.expected" rows="3" class="input font-mono text-xs" placeholder="93.184.216.34"></textarea>
+            <p x-show="monitorForm.type === 'change'" class="text-xs text-slate-400 dark:text-slate-500 mt-1">Leave empty to capture the baseline on the first run.</p>
+          </div>
+
+          <!-- Scheduler binding -->
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Schedule</label>
+            <div class="flex items-center gap-2">
+              <select x-model="monitorForm.scheduler_id" class="input">
+                <option value="">— none —</option>
+                <template x-for="s in schedules" :key="s.id">
+                  <option :value="s.id" x-text="s.name + ' (' + s.cron + ')'"></option>
+                </template>
+              </select>
+              <button type="button" @click="newSchedulerOpen = !newSchedulerOpen" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 whitespace-nowrap">+ New</button>
+            </div>
+            <div x-show="newSchedulerOpen" class="mt-2 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/40 flex flex-wrap items-end gap-2">
+              <div class="flex-1 min-w-[8rem]">
+                <label class="block text-xs text-slate-500 mb-1">Name</label>
+                <input type="text" x-model="newSchedulerForm.name" class="input-sm" placeholder="Hourly checks" />
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Cadence</label>
+                <select x-model="newSchedulerForm.cadence" class="input-sm">
+                  <option value="@hourly">Hourly</option>
+                  <option value="@daily">Daily</option>
+                  <option value="@weekly">Weekly</option>
+                  <option value="@monthly">Monthly</option>
+                  <option value="custom">Custom</option>
+                </select>
+              </div>
+              <input x-show="newSchedulerForm.cadence === 'custom'" type="text" x-model="newSchedulerForm.cron" class="input-sm font-mono" placeholder="*/15 * * * *" />
+              <button type="button" @click="createInlineScheduler()" class="btn-sm bg-indigo-600 text-white">Create</button>
+            </div>
+          </div>
+
+          <!-- Channel binding -->
+          <div>
+            <label class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Notification channel</label>
+            <div class="flex items-center gap-2">
+              <select x-model="monitorForm.channel_id" class="input">
+                <option value="">— none —</option>
+                <template x-for="c in notifications" :key="c.id">
+                  <option :value="c.id" x-text="(c.name || '(unnamed)') + ' · ' + channelTypeLabel(c.type)"></option>
+                </template>
+              </select>
+              <button type="button" @click="newChannelOpen = !newChannelOpen" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 whitespace-nowrap">+ New</button>
+            </div>
+            <div x-show="newChannelOpen" class="mt-2 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/40 space-y-2">
+              <div class="grid sm:grid-cols-2 gap-2">
+                <div>
+                  <label class="block text-xs text-slate-500 mb-1">Type</label>
+                  <select x-model="newChannelForm.type" @change="onNewChannelType()" class="input-sm">
+                    <option value="shoutrrr">Shoutrrr</option>
+                    <option value="greenapi">WhatsApp (GreenAPI)</option>
+                    <option value="gowa">WhatsApp (go-whatsapp-web)</option>
+                  </select>
+                </div>
+                <div>
+                  <label class="block text-xs text-slate-500 mb-1">Name</label>
+                  <input type="text" x-model="newChannelForm.name" class="input-sm" placeholder="Ops alerts" />
+                </div>
+              </div>
+              <template x-for="field in channelFields(newChannelForm.type)" :key="field">
+                <div>
+                  <label class="block text-xs text-slate-500 mb-1" x-text="fieldLabel(field)"></label>
+                  <input :type="field.includes('password') || field === 'token' ? 'password' : 'text'" x-model="newChannelForm.config[field]" class="input-sm font-mono" autocomplete="off" />
+                </div>
+              </template>
+              <button type="button" @click="createInlineChannel()" class="btn-sm bg-indigo-600 text-white">Create</button>
+            </div>
+          </div>
+
+          <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+            <input type="checkbox" x-model="monitorForm.enabled" class="rounded" /> Enabled
+          </label>
+
+          <div class="flex items-center gap-2 pt-1">
+            <button @click="saveMonitor()" class="btn bg-indigo-600 hover:bg-indigo-700 text-white">
+              <span x-text="monitorEditId ? 'Save changes' : 'Add monitor'"></span>
+            </button>
+            <button @click="cancelMonitorEditor()" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Cancel</button>
+          </div>
+        </div>
+
+        <!-- Monitor list -->
+        <p x-show="monitors.length === 0 && !showMonitorEditor" class="text-sm text-slate-400 dark:text-slate-500 py-4">No monitors yet.</p>
+        <div x-show="monitors.length > 0" class="card overflow-hidden">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-slate-50/80 dark:bg-slate-800/40 text-xs text-slate-500 dark:text-slate-400">
+                <th class="text-left px-4 py-2.5 font-medium">Name</th>
+                <th class="text-left px-4 py-2.5 font-medium">Type</th>
+                <th class="text-left px-4 py-2.5 font-medium">Record</th>
+                <th class="text-left px-4 py-2.5 font-medium">Schedule</th>
+                <th class="text-left px-4 py-2.5 font-medium">Channel</th>
+                <th class="text-left px-4 py-2.5 font-medium">Status</th>
+                <th class="px-4 py-2.5"></th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 dark:divide-slate-800/60">
+              <template x-for="m in monitors" :key="m.id">
+                <tr>
+                  <td class="px-4 py-2.5 text-slate-900 dark:text-white" x-text="m.name"></td>
+                  <td class="px-4 py-2.5"><span class="badge-ok" x-text="monitorTypeLabel(m.type)"></span></td>
+                  <td class="px-4 py-2.5 font-mono text-xs"><span x-text="m.fqdn"></span> <span class="text-slate-400" x-text="m.record_type"></span></td>
+                  <td class="px-4 py-2.5 text-xs text-slate-500" x-text="schedulerName(m.scheduler_id)"></td>
+                  <td class="px-4 py-2.5 text-xs text-slate-500" x-text="channelName(m.channel_id)"></td>
+                  <td class="px-4 py-2.5"><span :class="m.enabled ? 'badge-ok' : 'badge-error'" x-text="m.enabled ? 'Enabled' : 'Disabled'"></span></td>
+                  <td class="px-4 py-2.5 text-right whitespace-nowrap">
+                    <button @click="viewHistory(m.id)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">History</button>
+                    <button @click="openEditMonitor(m)" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Edit</button>
+                    <button @click="deleteMonitor(m.id)" class="btn-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30">Delete</button>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- History modal -->
+        <div x-show="historyMonitorId" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40" @click.self="closeHistory()">
+          <div class="card w-full max-w-2xl max-h-[80vh] overflow-hidden flex flex-col">
+            <div class="px-4 py-3 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between">
+              <h3 class="text-sm font-semibold text-slate-900 dark:text-white">Changelog</h3>
+              <button @click="closeHistory()" class="btn-sm ring-1 ring-slate-200 dark:ring-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">Close</button>
+            </div>
+            <div class="overflow-y-auto">
+              <p x-show="historyEvents.length === 0" class="text-sm text-slate-400 dark:text-slate-500 p-4">No history yet.</p>
+              <table x-show="historyEvents.length > 0" class="w-full text-sm">
+                <tbody class="divide-y divide-slate-100 dark:divide-slate-800/60">
+                  <template x-for="e in historyEvents" :key="e.id">
+                    <tr>
+                      <td class="px-4 py-2.5 text-xs text-slate-400 whitespace-nowrap" x-text="new Date(e.timestamp).toLocaleString()"></td>
+                      <td class="px-4 py-2.5"><span class="badge-ok" x-text="e.status"></span></td>
+                      <td class="px-4 py-2.5 text-xs">
+                        <div class="text-slate-700 dark:text-slate-300" x-text="e.message"></div>
+                        <div class="font-mono text-slate-400" x-text="(e.observed || []).join(', ')"></div>
+                      </td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </section>
 
     </div>


### PR DESCRIPTION
  ## Summary
  Adds DNS monitors and pulls the evaluation engine forward so they can be run on demand. A monitor watches a record and alerts on a **propagation failure** (expected values haven't reached every
  resolver) or an **unexpected change** (value drifted from a baseline). Monitors bind to a schedule (cadence) and a notification channel, and keep a per-monitor changelog. Also disables response
  caching so every check is live.

  ## Monitors
  - **Two types:**
    - *Propagation* — alert unless every responding resolver returns the expected value(s).
    - *Change detection* — compare the observed consensus to a baseline; capture the baseline on first run, alert + **re-baseline** on each distinct change.
  - **Model & storage:** `settings.Monitor` (type, FQDN, record type, `expected[]` = expected/baseline, `scheduler_id`, `channel_id`, enabled) + `settings.MonitorEvent` changelog. CRUD + events across
  sqlite & postgres (migration `0003`); round-trip tests.
  - **API** (`/api/v1/settings/monitors`, auth-gated): list / create / update / delete, `{id}/history`, and `{id}/run`. OpenAPI + handler tests.
  - **Evaluator** (`internal/monitor`): runs a check, decides status, appends a changelog entry, and notifies the bound channel on an alert. Used by the manual **Run** action now and the scheduled
  engine later. Unit-tested (match/mismatch, baseline→change→re-baseline, notification firing).

  ## UI
  - Settings → **Monitors** tab: add/edit form (type-conditional expected/baseline; **bind to an existing scheduler/channel** — selection only), list with **Run / History / Edit / Delete**, and a
  changelog modal.
  - Home-page results gain a **Create monitor** action (Propagation / Change-detection) that hands off FQDN, record type, and observed values into the prefilled form.

  ## No caching
  - Default `cache.driver` is now `none`: propagation, reverse, and DNS lookup always query resolvers live.
  - Monitors force `CheckRequest.NoCache` so they stay fresh regardless of cache config.
  - Updated example config, docs, and the sqlite compose file.

  ## Test plan
  - [x] `go build ./...`, `go vet`, `go test ./...` pass
  - [x] Browser: create monitor (both types) incl. home-page handoff; edit/delete; history modal; **Run** triggers a live evaluation and records a changelog entry
  - [x] Manual run of a propagation monitor against example.com → `not_propagated` with observed values
  - [x] Cache off verified via `dnsmon_cache_hits_total`: repeat check stays 0 (was 124 with memory cache); monitor runs never read cache
  - [ ] Real Postgres backend (validated against SQLite; Postgres mirrors the same SQL)