### PR TITLE
 CI: add Release and Docker Build workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+bin/
+tmp/
+*.db
+*.db-shm
+*.db-wal
+web/node_modules

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Docker Build
+
+on:
+  workflow_dispatch: {}
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version from latest tag
+        id: version
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Image version: $VERSION"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.VERSION }}
+          tags: |
+            techblog/dnsmon:latest
+            techblog/dnsmon:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,66 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (leave empty to auto-compute via next-version.sh)"
+        required: false
+        type: string
 
 jobs:
   release:
-    name: Release
+    name: Build and Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
-          cache: true
+          go-version-file: go.mod
 
-      - uses: actions/setup-node@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Build frontend
+        working-directory: web
+        run: npm ci && npm run build
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(bash scripts/next-version.sh)
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Build all targets
+        run: BUILD_MODE=prod VERSION=${{ steps.version.outputs.VERSION }} bash scripts/build.sh
+
+      - name: Create git tag
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.VERSION }}"
+          git push origin "${{ steps.version.outputs.VERSION }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          name: ${{ steps.version.outputs.VERSION }}
+          files: dist/*
+          generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: build the embedded frontend assets (Tailwind CSS + copied HTML/JS).
+FROM node:20-alpine AS frontend
+WORKDIR /app/web
+COPY web/package*.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+# Stage 2: cross-compile the Go binary for the target platform.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# Bring in the built frontend (overwrites web/dist so //go:embed dist sees fresh assets).
+COPY --from=frontend /app/web/dist web/dist
+
+ARG VERSION=dev
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
+    go build -trimpath \
+      -ldflags="-s -w -X github.com/t0mer/dnsmon/internal/version.Version=${VERSION}" \
+      -o /dnsmon ./cmd/dnsmon
+
+# Stage 3: minimal distroless runtime.
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /dnsmon /dnsmon
+EXPOSE 8080
+ENTRYPOINT ["/dnsmon"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  dnsmon:
+    image: techblog/dnsmon:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      # Server port (Docker/PaaS convention).
+      PORT: "8080"
+      # SQLite by default; data persists in the named volume.
+      DNSMON_STORAGE_DRIVER: "sqlite"
+      DNSMON_STORAGE_DSN: "file:/data/dnsmon.db?cache=shared&_fk=1"
+      DNSMON_LOG_FORMAT: "json"
+    volumes:
+      - dnsmondata:/data
+    restart: unless-stopped
+
+volumes:
+  dnsmondata:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Cross-compiles dnsmon into release archives under dist/.
+# Assumes the embedded frontend (web/dist) has already been built.
+#
+#   VERSION     version string baked into the binary (default: dev)
+#   BUILD_MODE  "prod" builds all release targets; anything else builds only
+#               the host platform (default: dev)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${VERSION:-dev}"
+BUILD_MODE="${BUILD_MODE:-dev}"
+COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo none)"
+DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+MODULE="github.com/t0mer/dnsmon"
+LDFLAGS="-s -w \
+  -X ${MODULE}/internal/version.Version=${VERSION} \
+  -X ${MODULE}/internal/version.Commit=${COMMIT} \
+  -X ${MODULE}/internal/version.Date=${DATE}"
+
+OUT="dist"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+build() {
+  local goos="$1" goarch="$2" goarm="${3:-}"
+  local suffix="$goarch"
+  [ -n "$goarm" ] && suffix="${goarch}v${goarm}"
+  local name="dnsmon_${VERSION}_${goos}_${suffix}"
+  local bin="dnsmon"
+  [ "$goos" = "windows" ] && bin="dnsmon.exe"
+
+  local dir="$OUT/$name"
+  mkdir -p "$dir"
+  echo "==> building $name"
+  CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" GOARM="$goarm" \
+    go build -trimpath -ldflags="$LDFLAGS" -o "$dir/$bin" ./cmd/dnsmon
+
+  cp README.md LICENSE "$dir/" 2>/dev/null || true
+
+  if [ "$goos" = "windows" ]; then
+    (cd "$OUT" && zip -qr "${name}.zip" "$name")
+  else
+    tar -C "$OUT" -czf "${OUT}/${name}.tar.gz" "$name"
+  fi
+  rm -rf "$dir"
+}
+
+if [ "$BUILD_MODE" = "prod" ]; then
+  build linux amd64
+  build linux arm64
+  build linux arm 7
+  build darwin amd64
+  build darwin arm64
+  build windows amd64
+else
+  build "$(go env GOOS)" "$(go env GOARCH)"
+fi
+
+echo "==> artifacts:"
+ls -1 "$OUT"

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Prints the next semver tag by bumping the patch of the latest vMAJOR.MINOR.PATCH
+# git tag. Defaults to v0.1.0 when no tags exist.
+set -euo pipefail
+
+latest="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+if [ -z "$latest" ]; then
+  echo "v0.1.0"
+  exit 0
+fi
+
+ver="${latest#v}"
+IFS='.' read -r major minor patch <<<"$ver"
+major="${major:-0}"
+minor="${minor:-0}"
+patch="${patch:-0}"
+
+echo "v${major}.${minor}.$((patch + 1))"

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,9 @@
   "name": "dnsmon-web",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "build": "tailwindcss -i src/css/tailwind.src.css -o dist/css/app.css --minify && mkdir -p dist/js && cp src/js/*.js dist/js/ && cp src/*.html dist/"
+  },
   "devDependencies": {
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",


### PR DESCRIPTION
  ## Summary
  Adds two GitHub Actions workflows and the files they depend on, replacing the previous goreleaser-based release.

  - **Release** (`workflow_dispatch`) — builds the embedded frontend, resolves a version, cross-compiles all targets, tags the repo, and publishes a GitHub Release with the archives.
  - **Docker Build** — multi-arch image build/push to Docker Hub, triggered manually or automatically after a successful Release.

  ## Release workflow (`0d8f775`)
  - `.github/workflows/release.yml`: manual trigger with an optional `version` input; on empty it auto-computes via `scripts/next-version.sh`. Steps: build frontend (`npm run build`) → resolve
  version → `scripts/build.sh` → push tag → `softprops/action-gh-release` with `dist/*` and generated notes.
  - `scripts/next-version.sh` — prints the next `vX.Y.Z` (bumps patch of the latest tag; `v0.1.0` if none).
  - `scripts/build.sh` — cross-compiles release archives into `dist/` for linux amd64/arm64/arm-v7, darwin amd64/arm64, windows amd64; injects version/commit/date via ldflags. Honors `VERSION` and
  `BUILD_MODE` (prod = all targets).
  - `web/package.json` — adds the `build` script used by `npm run build`.

  ## Docker workflow (`749d184`)
  - `.github/workflows/docker.yml` ("Docker Build"): runs on `workflow_dispatch` or after the Release workflow completes successfully; QEMU + Buildx; pushes `techblog/dnsmon:latest` and
  `:<latest-tag>` for `linux/amd64,arm64,arm/v7`.
  - `Dockerfile` (repo root — the workflow uses `context: .`): multi-stage, multi-arch — Node stage builds the embedded frontend, Go stage cross-compiles per `TARGETOS/TARGETARCH/TARGETVARIANT` with
  the `VERSION` ldflag, distroless runtime. Uses the `github.com/t0mer/dnsmon` module path and `./cmd/dnsmon`.
  - `docker-compose.yml` — runs `techblog/dnsmon:latest` with SQLite defaults.
  - `.dockerignore` — excludes `.git`, `node_modules`, `bin`, `*.db` from the build context.

  ## Required secrets
  `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (for the Docker push).

  ## Test plan
  - [x] Both workflow YAMLs parse
  - [x] `scripts/next-version.sh` → `v0.1.0` (no tags)
  - [x] `npm run build` produces `web/dist` assets
  - [x] `BUILD_MODE=prod`/host `scripts/build.sh` cross-compiles archives; the built binary runs and `/api/v1/version` reports the injected version/commit/date
  - [ ] Real multi-arch `docker buildx` push (not runnable in the dev sandbox; standard buildx pattern)
