### PR TITLE
UI fixes: drop Live button & PNG/SVG export, real check progress, robust Share

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -37,6 +39,21 @@ type responseRecorder struct {
 func (rr *responseRecorder) WriteHeader(code int) {
 	rr.status = code
 	rr.ResponseWriter.WriteHeader(code)
+}
+
+// Unwrap exposes the underlying ResponseWriter so http.ResponseController can
+// reach capabilities like Hijack/Flush.
+func (rr *responseRecorder) Unwrap() http.ResponseWriter {
+	return rr.ResponseWriter
+}
+
+// Hijack lets WebSocket upgrades work through the logging wrapper.
+func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := rr.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
+	}
+	return hj.Hijack()
 }
 
 // Logger returns a middleware that logs each request using slog.

--- a/internal/api/v1/stream.go
+++ b/internal/api/v1/stream.go
@@ -46,24 +46,36 @@ func StreamCheck(chkr *checker.Checker) http.HandlerFunc {
 		}
 		defer conn.CloseNow()
 
-		ctx := conn.CloseRead(r.Context())
-
+		// Read the request frame first, then switch to read-close so a client
+		// disconnect cancels the stream (CloseRead would otherwise consume the
+		// request frame and close the connection before we read it).
 		var req wsStreamRequest
-		if err := wsjson.Read(ctx, conn, &req); err != nil {
-			sendWSError(ctx, conn, apierr.ErrCodeInvalidInput, "Failed to read request.")
+		if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+			sendWSError(r.Context(), conn, apierr.ErrCodeInvalidInput, "Failed to read request.")
 			return
 		}
 
 		if req.Name == "" || req.Type == "" {
-			sendWSError(ctx, conn, apierr.ErrCodeInvalidInput, "name and type are required.")
+			sendWSError(r.Context(), conn, apierr.ErrCodeInvalidInput, "name and type are required.")
 			return
 		}
 
-		resultCh, doneCh := chkr.Stream(ctx, checker.StreamRequest{
+		ctx := conn.CloseRead(r.Context())
+
+		total, id, resultCh, doneCh, err := chkr.Stream(ctx, checker.StreamRequest{
 			Name:        req.Name,
 			Type:        req.Type,
 			ResolverIDs: req.Resolvers,
-		})
+		}, true)
+		if err != nil {
+			sendWSError(ctx, conn, apierr.ErrCodeInvalidInput, err.Error())
+			return
+		}
+
+		// Announce the resolver count up front so the client can show progress.
+		if err := wsjson.Write(ctx, conn, wsMessage{Type: "total", Data: map[string]int{"total": total}}); err != nil {
+			return
+		}
 
 		for result := range resultCh {
 			msg := wsMessage{Type: "result", Data: result}
@@ -73,7 +85,6 @@ func StreamCheck(chkr *checker.Checker) http.HandlerFunc {
 		}
 
 		if summary, ok := <-doneCh; ok && summary != nil {
-			id := checker.NewID(req.Name, req.Type)
 			msg := wsMessage{
 				Type: "done",
 				Data: wsDoneData{Summary: *summary, ID: id},

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -200,10 +200,13 @@ func TestStream_DeliversResults(t *testing.T) {
 	store := &storage.Noop{}
 	c := checker.New(client, reg, &mockCache{}, store, testConfig())
 
-	resultCh, doneCh := c.Stream(context.Background(), checker.StreamRequest{
+	total, id, resultCh, doneCh, err := c.Stream(context.Background(), checker.StreamRequest{
 		Name: "example.com",
 		Type: "A",
-	})
+	}, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.NotEmpty(t, id)
 
 	var results []*dnsclient.ResolverResult
 	for r := range resultCh {

--- a/internal/checker/stream.go
+++ b/internal/checker/stream.go
@@ -17,32 +17,37 @@ type StreamRequest struct {
 	AllowPrivate    bool
 }
 
-// Stream fans out DNS queries and pushes results to the returned channel as they arrive.
-// The done channel receives the final CheckSummary when all resolvers have responded.
-// Both channels are closed when the check completes or ctx is cancelled.
-func (c *Checker) Stream(ctx context.Context, req StreamRequest) (<-chan *dnsclient.ResolverResult, <-chan *dnsclient.CheckSummary) {
+// Stream fans out DNS queries and pushes each ResolverResult to the results
+// channel as it arrives; the done channel receives the final CheckSummary.
+// Validation and resolver-list resolution happen synchronously so the caller
+// gets the total resolver count (for progress reporting) and a stable check ID
+// up front; an error is returned if the request is invalid. When save is true
+// the completed check is persisted under that ID. Both channels close when the
+// check completes or ctx is cancelled.
+func (c *Checker) Stream(ctx context.Context, req StreamRequest, save bool) (int, string, <-chan *dnsclient.ResolverResult, <-chan *dnsclient.CheckSummary, error) {
+	checkReq := CheckRequest{
+		Name:            req.Name,
+		Type:            req.Type,
+		ResolverIDs:     req.ResolverIDs,
+		CustomResolvers: req.CustomResolvers,
+		AllowPrivate:    req.AllowPrivate,
+	}
+	if err := validateRequest(checkReq); err != nil {
+		return 0, "", nil, nil, err
+	}
+
+	resolverList, err := c.buildResolverList(ctx, checkReq)
+	if err != nil {
+		return 0, "", nil, nil, err
+	}
+
+	id := NewID(req.Name, req.Type)
 	resultCh := make(chan *dnsclient.ResolverResult, 64)
 	doneCh := make(chan *dnsclient.CheckSummary, 1)
 
 	go func() {
 		defer close(resultCh)
 		defer close(doneCh)
-
-		checkReq := CheckRequest{
-			Name:            req.Name,
-			Type:            req.Type,
-			ResolverIDs:     req.ResolverIDs,
-			CustomResolvers: req.CustomResolvers,
-			AllowPrivate:    req.AllowPrivate,
-		}
-		if err := validateRequest(checkReq); err != nil {
-			return
-		}
-
-		resolverList, err := c.buildResolverList(ctx, checkReq)
-		if err != nil {
-			return
-		}
 
 		concurrency := c.cfg.DNS.PerResolverConcurrency
 		if concurrency <= 0 {
@@ -63,7 +68,7 @@ func (c *Checker) Stream(ctx context.Context, req StreamRequest) (<-chan *dnscli
 				sem <- struct{}{}
 				defer func() { <-sem }()
 
-				result := c.queryWithCache(ctx, resolver, req.Name, req.Type, false)
+				result := c.queryWithCache(ctx, resolver, req.Name, req.Type, true)
 
 				c.m.queryTotal.WithLabelValues(resolver.ID, result.Status).Inc()
 				c.m.queryDuration.WithLabelValues(resolver.ID, result.Status).
@@ -83,28 +88,32 @@ func (c *Checker) Stream(ctx context.Context, req StreamRequest) (<-chan *dnscli
 
 		wg.Wait()
 
-		summary := buildSummary(results)
-		select {
-		case doneCh <- &summary:
-		default:
+		// Don't persist a partial check if the client disconnected mid-stream.
+		if ctx.Err() != nil {
+			return
 		}
+
+		summary := buildSummary(results)
+		status := "ok"
+		if summary.Errors > 0 || summary.Timeouts > 0 {
+			status = "partial"
+		}
+		c.m.checkTotal.WithLabelValues(req.Type, status).Inc()
+
+		if save {
+			check := &dnsclient.Check{
+				ID:        id,
+				Name:      req.Name,
+				Type:      req.Type,
+				CreatedAt: time.Now().UTC(),
+				Results:   results,
+				Summary:   summary,
+			}
+			_ = c.storage.SaveCheck(ctx, check)
+		}
+
+		doneCh <- &summary
 	}()
 
-	return resultCh, doneCh
-}
-
-// streamQueryWithCache is the streaming variant — uses the same cache logic but
-// sets a minimal TTL for streaming results to avoid stale data.
-func (c *Checker) streamQueryWithCache(ctx context.Context, resolver dnsclient.Resolver, name, qtype string) *dnsclient.ResolverResult {
-	qtypeNum, _ := dnsclient.ParseType(qtype)
-	result, err := c.client.Query(ctx, resolver, name, qtypeNum)
-	if err != nil {
-		return &dnsclient.ResolverResult{
-			Resolver:  resolver,
-			Status:    dnsclient.StatusError,
-			Error:     err.Error(),
-			QueriedAt: time.Now().UTC(),
-		}
-	}
-	return result
+	return len(resolverList), id, resultCh, doneCh, nil
 }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -128,23 +128,10 @@
             <div class="flex flex-wrap items-center gap-2">
               <button type="submit"
                 class="btn bg-white hover:bg-indigo-50 text-indigo-700 font-semibold shadow-md flex-shrink-0"
-                :disabled="loading || liveActive"
+                :disabled="loading"
                 aria-label="Run DNS propagation check">
-                <svg class="w-4 h-4" :class="{ 'animate-spin': loading && !liveActive }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-                <span x-text="loading && !liveActive ? 'Checking…' : 'Check'"></span>
-              </button>
-
-              <button type="button" @click="toggleLive()"
-                class="btn ring-1 ring-white/30 font-medium flex-shrink-0"
-                :class="liveActive
-                  ? 'bg-rose-500/20 hover:bg-rose-500/30 text-rose-200 ring-rose-400/30'
-                  : 'bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-100 ring-emerald-400/30'"
-                aria-label="Toggle live streaming">
-                <span class="relative flex h-2 w-2 flex-shrink-0">
-                  <span x-show="liveActive" class="animate-ping absolute inline-flex h-full w-full rounded-full bg-rose-400 opacity-75" aria-hidden="true"></span>
-                  <span class="relative inline-flex rounded-full h-2 w-2" :class="liveActive ? 'bg-rose-400' : 'bg-emerald-400'" aria-hidden="true"></span>
-                </span>
-                <span x-text="liveActive ? 'Stop Live' : 'Live'"></span>
+                <svg class="w-4 h-4" :class="{ 'animate-spin': loading }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                <span x-text="loading ? 'Checking…' : 'Check'"></span>
               </button>
 
               <button type="button" x-show="checkId" @click="share()"
@@ -165,7 +152,7 @@
                 <div x-show="exportOpen" @click.outside="exportOpen = false" x-transition
                   class="absolute right-0 top-full mt-1.5 w-36 card py-1 z-20 shadow-xl"
                   role="menu">
-                  <template x-for="fmt in ['json','csv','png','svg','pdf']" :key="fmt">
+                  <template x-for="fmt in ['json','csv','pdf']" :key="fmt">
                     <button type="button"
                       @click="exportResults(fmt); exportOpen = false"
                       class="w-full text-left px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 font-mono uppercase text-xs"

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -93,44 +93,56 @@ function dnsmonApp() {
     },
 
     // ---------------------------------------------------------------------------
-    // Check (HTTP)
+    // Check (streamed over WebSocket so the progress bar reflects real progress
+    // as each resolver responds).
     // ---------------------------------------------------------------------------
-    async check() {
+    check() {
       if (!this.domain.trim()) return;
       this._resetResults();
       this.loading = true;
       this.errorMsg = '';
+      this.progressLabel = 'Querying resolvers…';
 
-      try {
-        const resp = await fetch('/api/v1/check', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: this.domain.trim(),
-            type: this.type,
-            save: true,
-          }),
-        });
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const ws = new WebSocket(`${proto}//${window.location.host}/api/v1/check/stream`);
+      let total = 0;
+      let received = 0;
 
-        if (!resp.ok) {
-          const err = await resp.json().catch(() => ({ error: { message: resp.statusText } }));
-          throw new Error(err?.error?.message || `HTTP ${resp.status}`);
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ name: this.domain.trim(), type: this.type }));
+      };
+
+      ws.onmessage = (event) => {
+        let msg;
+        try { msg = JSON.parse(event.data); } catch { return; }
+
+        if (msg.type === 'total') {
+          total = msg.data?.total || 0;
+          this.progressLabel = `Querying ${total} resolvers…`;
+        } else if (msg.type === 'result' && msg.data) {
+          this.results.push(msg.data);
+          received++;
+          this.progressPct = total > 0 ? Math.round((received / total) * 100) : 0;
+          if (this._markerLayer) {
+            window.updateMarkers(this._markerLayer, this.results);
+          }
+        } else if (msg.type === 'done' && msg.data) {
+          this.summary = msg.data.summary || null;
+          this.checkId = msg.data.id || '';
+          this.progressPct = 100;
+        } else if (msg.type === 'error') {
+          this.errorMsg = msg.data?.message || 'Check failed.';
         }
+      };
 
-        const data = await resp.json();
-        this.results = data.results || [];
-        this.summary = data.summary || null;
-        this.checkId = data.id || '';
-        this.progressPct = 100;
-
-        if (this._markerLayer) {
-          window.updateMarkers(this._markerLayer, this.results);
-        }
-      } catch (err) {
-        this.errorMsg = err.message;
-      } finally {
+      ws.onerror = () => {
+        this.errorMsg = 'Connection to the server failed.';
         this.loading = false;
-      }
+      };
+
+      ws.onclose = () => {
+        this.loading = false;
+      };
     },
 
 

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -52,15 +52,9 @@ function dnsmonApp() {
     checkId: '',
     shareLabel: 'Share',
 
-    // Live / WebSocket
-    liveActive: false,
-    _ws: null,
-
     // Progress
     progressPct: 0,
     progressLabel: 'Querying resolvers...',
-    _totalResolvers: 0,
-    _receivedCount: 0,
 
     // Sorting
     sortBy: 'country',
@@ -139,81 +133,6 @@ function dnsmonApp() {
       }
     },
 
-    // ---------------------------------------------------------------------------
-    // Live check (WebSocket)
-    // ---------------------------------------------------------------------------
-    toggleLive() {
-      if (this.liveActive) {
-        this._stopLive();
-      } else {
-        this._startLive();
-      }
-    },
-
-    _startLive() {
-      if (!this.domain.trim()) return;
-      this._resetResults();
-      this.liveActive = true;
-      this.loading = true;
-      this.errorMsg = '';
-
-      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const wsUrl = `${proto}//${window.location.host}/api/v1/check/stream`;
-      this._ws = new WebSocket(wsUrl);
-
-      this._ws.onopen = () => {
-        this._ws.send(JSON.stringify({ name: this.domain.trim(), type: this.type }));
-      };
-
-      this._ws.onmessage = (event) => {
-        let msg;
-        try { msg = JSON.parse(event.data); } catch { return; }
-
-        if (msg.type === 'result' && msg.data) {
-          this.results.push(msg.data);
-          this._receivedCount++;
-          if (this._totalResolvers > 0) {
-            this.progressPct = Math.round((this._receivedCount / this._totalResolvers) * 100);
-          }
-          if (this._markerLayer) {
-            window.updateMarkers(this._markerLayer, this.results);
-          }
-        } else if (msg.type === 'total' && msg.data) {
-          this._totalResolvers = msg.data.total || 0;
-          this.progressLabel = `Querying ${this._totalResolvers} resolvers...`;
-        } else if (msg.type === 'done' && msg.data) {
-          this.summary = msg.data.summary || null;
-          this.checkId = msg.data.id || '';
-          this.progressPct = 100;
-          this.loading = false;
-          this.liveActive = false;
-          this._ws = null;
-        } else if (msg.type === 'error') {
-          this.errorMsg = msg.data?.message || 'Stream error';
-          this._stopLive();
-        }
-      };
-
-      this._ws.onerror = () => {
-        this.errorMsg = 'WebSocket connection failed.';
-        this._stopLive();
-      };
-
-      this._ws.onclose = () => {
-        this.loading = false;
-        this.liveActive = false;
-        this._ws = null;
-      };
-    },
-
-    _stopLive() {
-      if (this._ws) {
-        this._ws.close();
-        this._ws = null;
-      }
-      this.liveActive = false;
-      this.loading = false;
-    },
 
     // ---------------------------------------------------------------------------
     // Permalink
@@ -381,8 +300,6 @@ function dnsmonApp() {
       this.checkId = '';
       this.progressPct = 0;
       this.progressLabel = 'Querying resolvers...';
-      this._receivedCount = 0;
-      this._totalResolvers = 0;
       this.shareLabel = 'Share';
       this.page = 1;
       if (this._markerLayer) {

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -173,13 +173,41 @@ function dnsmonApp() {
 
     share() {
       if (!this.checkId) return;
+      // Build the link from the address the browser is on, so it works behind a
+      // reverse proxy / on any host (not just localhost).
       const url = `${window.location.origin}/check/${this.checkId}`;
-      navigator.clipboard.writeText(url).then(() => {
+      this._copyLink(url);
+    },
+
+    _copyLink(text) {
+      const copied = () => {
         this.shareLabel = 'Copied!';
         setTimeout(() => { this.shareLabel = 'Share'; }, 2000);
-      }).catch(() => {
-        window.prompt('Copy this link:', url);
-      });
+      };
+      // The async Clipboard API only exists in a secure context (HTTPS or
+      // localhost); on plain-HTTP hosts it's undefined, so guard and fall back.
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(text).then(copied).catch(() => this._fallbackCopy(text, copied));
+      } else {
+        this._fallbackCopy(text, copied);
+      }
+    },
+
+    _fallbackCopy(text, copied) {
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.top = '-1000px';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        if (ok) { copied(); return; }
+      } catch (_) { /* fall through to prompt */ }
+      window.prompt('Copy this link:', text);
     },
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
  ## Summary
  A batch of propagation-page UI fixes:
  1. Remove the **Live** button and the **PNG/SVG** export options.
  2. Show **real progress** during a check instead of jumping 0% → 100%.
  3. Make the **Share** button copy correctly over plain HTTP / behind a reverse proxy.

  ## 1. Remove Live button + PNG/SVG export (`160a6ff`)
  - Dropped the Live (WebSocket toggle) button and its now-dead client code (`toggleLive`/`_startLive`/`_stopLive`, `liveActive`/`_ws` state, progress counters); the Check button no longer depends on
   `liveActive`.
  - Export menu reduced to **JSON / CSV / PDF**.
  - The `/api/v1/check/stream` endpoint and PNG/SVG export handlers remain in the API; they're just no longer surfaced in the UI.

  ## 2. Real progress during a check (`291da1e`)
  The check ran as one blocking POST that returned everything at once, so the bar sat at 0% then jumped to 100%. **Check** now streams over `/api/v1/check/stream`, advancing the bar per resolver and
  rendering results + map markers incrementally. To support this and keep Share/Export/permalinks working:
  - `checker.Stream` validates synchronously and returns the resolver **count** + a stable **check ID** up front, then **persists** the completed check under that ID (queries run uncached/live).
  - The WebSocket handler emits a `total` frame first and reads the request frame **before** `CloseRead` (the old order consumed the request and closed the socket, so no frames were ever sent).
  - The `Logger` middleware's `responseRecorder` now implements `Hijack`/`Unwrap`, so WebSocket upgrades succeed — this 501 is why the old Live button never actually connected.

  ## 3. Robust Share copy (`1d4476e`)
  The link was already built from `window.location.origin` (correct, host-aware), but the copy called `navigator.clipboard` unconditionally. On a non-secure context (plain HTTP on a LAN IP / behind a
   proxy) `navigator.clipboard` is `undefined`, so the call threw *synchronously* — `.catch()` never ran and the button silently did nothing. `share()` now delegates to `_copyLink()`: async Clipboard
   API in a secure context, else a hidden-`<textarea>` `execCommand('copy')` fallback, then `window.prompt`.

  ## Test plan
  - [x] No Live button; Export shows only JSON/CSV/PDF
  - [x] Progress bar shows intermediate values (e.g. 51%) and results stream in; the check is saved and fetchable by ID (Share/Export/permalink work)
  - [x] WebSocket upgrade succeeds (previously 501 via the logging middleware)
  - [x] Share over `http://192.168.0.253:8080` (insecure context) copies `http://192.168.0.253:8080/check/<id>` via the fallback; "Copied!" shown
  - [x] `go build ./...`, `go vet`, `go test ./...` pass
