### PR TITLE
feat: propagation ETA, snapshot diff, and authoritative trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ private whatsmydns.
 - 🌍 **Propagation check** across 124 curated global resolvers, with an
   interactive world map, consensus summary, country flags, and a sortable,
   paginated results table.
+- ⏱️ **Propagation ETA** — estimates how long until full propagation based on
+  the maximum TTL observed across resolvers still serving an old answer.
+  Shows convergence % and a human-readable countdown (e.g. "~2m 30s").
+- 📸 **Snapshot diff** — save a check result as a baseline, then re-run to
+  see a per-resolver Δ column (changed / unchanged). A "Changed only" filter
+  narrows the table to just the resolvers that flipped, making in-progress
+  propagation easy to track.
+- 🔗 **Authoritative trace** — walks the full DNS delegation chain from root
+  nameservers down to the authoritative server, equivalent to `dig +trace`.
+  Each hop shows the zone, nameserver IP, referral or authoritative status,
+  answer records, and round-trip time.
 - 🔎 **DNS Lookup** — full single-resolver response (Answer / Authority /
   Additional sections, TTLs, flags) against any resolver or custom IP.
 - 🔁 **Reverse DNS** — PTR lookups for IPv4/IPv6 across all resolvers.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -83,6 +83,10 @@ func (s *Server) routes() {
 		r.URL.Path = "/reverse.html"
 		fileServer.ServeHTTP(w, r)
 	})
+	r.Get("/trace", func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = "/trace.html"
+		fileServer.ServeHTTP(w, r)
+	})
 	r.Get("/about", func(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = "/about.html"
 		fileServer.ServeHTTP(w, r)
@@ -120,6 +124,7 @@ func (s *Server) routes() {
 
 		r.Post("/lookup", v1.PostLookup(s.checker))
 		r.Post("/reverse", v1.PostReverse(s.checker))
+		r.Post("/trace", v1.PostTrace(s.checker))
 
 		// Authentication (public so the login form can reach it)
 		r.Post("/auth/login", v1.Login(s.storage))

--- a/internal/api/v1/trace.go
+++ b/internal/api/v1/trace.go
@@ -1,0 +1,48 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/t0mer/dnsmon/internal/api/apierr"
+	"github.com/t0mer/dnsmon/internal/checker"
+)
+
+// TraceRequest is the request body for POST /api/v1/trace.
+type TraceRequest struct {
+	Name string `json:"name" validate:"required"`
+	Type string `json:"type" validate:"required"`
+}
+
+// PostTrace handles POST /api/v1/trace.
+func PostTrace(chkr *checker.Checker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req TraceRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				"Invalid request body.", nil)
+			return
+		}
+
+		if err := validate.Struct(req); err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				err.Error(), nil)
+			return
+		}
+
+		if !domainRE.MatchString(req.Name) {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidDomain,
+				"Invalid domain name.", nil)
+			return
+		}
+
+		result, err := chkr.Trace(r.Context(), req.Name, req.Type)
+		if err != nil {
+			apierr.WriteError(w, r, http.StatusBadRequest, apierr.ErrCodeInvalidInput,
+				err.Error(), nil)
+			return
+		}
+
+		apierr.WriteJSON(w, http.StatusOK, result)
+	}
+}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -347,6 +347,38 @@ func buildSummary(results []dnsclient.ResolverResult) dnsclient.CheckSummary {
 	}
 	s.UniqueAnswerSets = len(seen)
 
+	// Propagation convergence + ETA.
+	if s.Responded > 0 {
+		// Identify the majority answer set.
+		var majorityKey string
+		var majorityCount int
+		for k, n := range s.Consensus {
+			if n > majorityCount {
+				majorityCount = n
+				majorityKey = k
+			}
+		}
+		s.ConvergedPct = (majorityCount * 100) / s.Responded
+
+		// ETA = max TTL across resolvers not yet serving the majority answer.
+		var maxTTL uint32
+		for _, r := range results {
+			if r.Status != dnsclient.StatusOK {
+				continue
+			}
+			if answersKey(r.Answers) == majorityKey {
+				continue
+			}
+			for _, a := range r.Answers {
+				if a.TTL > maxTTL {
+					maxTTL = a.TTL
+				}
+			}
+		}
+		eta := int64(maxTTL)
+		s.PropagationETA = &eta
+	}
+
 	return s
 }
 

--- a/internal/checker/trace.go
+++ b/internal/checker/trace.go
@@ -1,0 +1,224 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/t0mer/dnsmon/internal/dnsclient"
+)
+
+// rootServers are the anycast addresses of IANA root nameservers used as
+// trace entry points. We hard-code IPv4 addresses to avoid a bootstrap
+// dependency on a recursive resolver.
+var rootServers = []string{
+	"198.41.0.4",   // a.root-servers.net
+	"199.9.14.201", // b.root-servers.net
+	"192.33.4.12",  // c.root-servers.net
+	"199.7.91.13",  // d.root-servers.net
+}
+
+const maxTraceSteps = 24
+
+// Trace walks the DNS delegation chain from the root nameservers down to the
+// authoritative server(s) for name, performing non-recursive queries at each
+// hop — equivalent to `dig +trace`.
+func (c *Checker) Trace(ctx context.Context, name, qtype string) (*dnsclient.TraceResult, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if _, ok := dnsclient.ParseType(qtype); !ok {
+		return nil, fmt.Errorf("unsupported record type: %s", qtype)
+	}
+	if !strings.HasSuffix(name, ".") {
+		name = name + "."
+	}
+
+	qtypeNum, _ := dnsclient.ParseType(qtype)
+	result := &dnsclient.TraceResult{
+		Name: strings.TrimSuffix(name, "."),
+		Type: qtype,
+	}
+
+	servers := make([]string, len(rootServers))
+	copy(servers, rootServers)
+
+	for step := 0; step < maxTraceSteps; step++ {
+		if len(servers) == 0 {
+			break
+		}
+		ts, next, done, err := c.traceStep(ctx, servers[0], name, qtypeNum, qtype)
+		result.Steps = append(result.Steps, ts)
+		if err != nil || done {
+			break
+		}
+		if len(next) == 0 {
+			break
+		}
+		servers = next
+	}
+
+	return result, nil
+}
+
+// traceStep sends one non-recursive query to serverIP and returns:
+//   - the populated TraceStep
+//   - the list of server IPs to query next (nil if authoritative or failed)
+//   - done=true when we have an authoritative answer
+//   - any hard error
+func (c *Checker) traceStep(ctx context.Context, serverIP, name string, qtypeNum uint16, qtype string) (dnsclient.TraceStep, []string, bool, error) {
+	ts := dnsclient.TraceStep{
+		IP:        serverIP,
+		QueryType: qtype,
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(name, qtypeNum)
+	msg.RecursionDesired = false
+	msg.SetEdns0(4096, false)
+
+	dc := &dns.Client{
+		Net:     "udp",
+		Timeout: c.cfg.DNS.QueryTimeout,
+	}
+
+	start := time.Now()
+	resp, _, err := dc.ExchangeContext(ctx, msg, net.JoinHostPort(serverIP, "53"))
+	ts.DurationMS = time.Since(start).Milliseconds()
+
+	if err != nil {
+		// Retry over TCP on truncation or timeout.
+		dc.Net = "tcp"
+		resp, _, err = dc.ExchangeContext(ctx, msg, net.JoinHostPort(serverIP, "53"))
+		ts.DurationMS = time.Since(start).Milliseconds()
+	}
+
+	if err != nil {
+		ts.Status = dnsclient.StatusError
+		ts.Error = err.Error()
+		return ts, nil, false, err
+	}
+
+	// Determine the zone label from the first NS record in the authority section.
+	if len(resp.Ns) > 0 {
+		ts.Zone = strings.TrimSuffix(resp.Ns[0].Header().Name, ".")
+		if ns, ok := resp.Ns[0].(*dns.NS); ok {
+			ts.Nameserver = strings.TrimSuffix(ns.Ns, ".")
+		}
+	} else if len(resp.Answer) > 0 {
+		ts.Zone = strings.TrimSuffix(resp.Answer[0].Header().Name, ".")
+		ts.Nameserver = serverIP
+	} else {
+		ts.Zone = "."
+		ts.Nameserver = serverIP
+	}
+
+	ts.Authoritative = resp.Authoritative
+	ts.Status = rcodeToStatus(resp.Rcode)
+
+	for _, rr := range resp.Answer {
+		ts.Answers = append(ts.Answers, dnsclient.RRToAnswer(rr))
+	}
+	for _, rr := range resp.Ns {
+		ts.Authority = append(ts.Authority, dnsclient.RRToAnswer(rr))
+	}
+	for _, rr := range resp.Extra {
+		if rr.Header().Rrtype == dns.TypeOPT {
+			continue
+		}
+		ts.Additional = append(ts.Additional, dnsclient.RRToAnswer(rr))
+	}
+
+	if resp.Authoritative {
+		return ts, nil, true, nil
+	}
+
+	// Gather glue records from the additional section. Prefer IPv4 over IPv6
+	// so the trace works in environments without IPv6 connectivity.
+	glueV4 := make(map[string]string)
+	glueV6 := make(map[string]string)
+	for _, rr := range resp.Extra {
+		switch a := rr.(type) {
+		case *dns.A:
+			key := strings.ToLower(strings.TrimSuffix(a.Hdr.Name, "."))
+			if !isPrivateOrLocal(a.A.String()) {
+				glueV4[key] = a.A.String()
+			}
+		case *dns.AAAA:
+			key := strings.ToLower(strings.TrimSuffix(a.Hdr.Name, "."))
+			if !isPrivateOrLocal(a.AAAA.String()) {
+				glueV6[key] = a.AAAA.String()
+			}
+		}
+	}
+	// Merge: IPv4 takes precedence.
+	glue := make(map[string]string)
+	for k, v := range glueV6 {
+		glue[k] = v
+	}
+	for k, v := range glueV4 {
+		glue[k] = v
+	}
+
+	// Build next-hop server list from NS records. We strongly prefer IPv4 so
+	// that the trace works in environments without IPv6 connectivity.
+	var next []string
+	seen := make(map[string]bool)
+	for _, rr := range resp.Ns {
+		ns, ok := rr.(*dns.NS)
+		if !ok {
+			continue
+		}
+		nsName := strings.ToLower(strings.TrimSuffix(ns.Ns, "."))
+
+		// 1. Use IPv4 glue first.
+		if ip, ok := glueV4[nsName]; ok && !seen[ip] {
+			seen[ip] = true
+			next = append(next, ip)
+			continue
+		}
+
+		// 2. Fall back to resolving IPv4 via the system resolver.
+		addrs, err := net.DefaultResolver.LookupIPAddr(ctx, nsName)
+		if err == nil {
+			for _, a := range addrs {
+				if a.IP.To4() != nil && !isPrivateOrLocal(a.IP.String()) && !seen[a.IP.String()] {
+					seen[a.IP.String()] = true
+					next = append(next, a.IP.String())
+					break
+				}
+			}
+			if len(next) > 0 {
+				continue
+			}
+		}
+
+		// 3. Last resort: use IPv6 glue.
+		if ip, ok := glueV6[nsName]; ok && !seen[ip] {
+			seen[ip] = true
+			next = append(next, ip)
+		}
+	}
+
+	return ts, next, false, nil
+}
+
+// rcodeToStatus maps a DNS RCODE integer to a status string.
+// Duplicated from dnsclient/client.go to keep the checker package self-contained.
+func rcodeToStatus(rcode int) string {
+	switch rcode {
+	case dns.RcodeSuccess:
+		return dnsclient.StatusOK
+	case dns.RcodeNameError:
+		return dnsclient.StatusNXDomain
+	case dns.RcodeServerFailure:
+		return dnsclient.StatusServFail
+	case dns.RcodeRefused:
+		return dnsclient.StatusRefused
+	default:
+		return dnsclient.StatusError
+	}
+}

--- a/internal/dnsclient/client.go
+++ b/internal/dnsclient/client.go
@@ -155,6 +155,9 @@ func isTimeout(err error) bool {
 	return ok && netErr.Timeout()
 }
 
+// RRToAnswer converts a miekg/dns resource record to an Answer.
+func RRToAnswer(rr dns.RR) Answer { return rrToAnswer(rr) }
+
 func rrToAnswer(rr dns.RR) Answer {
 	hdr := rr.Header()
 	a := Answer{

--- a/internal/dnsclient/result.go
+++ b/internal/dnsclient/result.go
@@ -2,6 +2,28 @@ package dnsclient
 
 import "time"
 
+// TraceStep represents one delegation hop in an authoritative trace.
+type TraceStep struct {
+	Zone          string   `json:"zone"`
+	Nameserver    string   `json:"nameserver"`
+	IP            string   `json:"ip"`
+	QueryType     string   `json:"query_type"`
+	Answers       []Answer `json:"answers,omitempty"`
+	Authority     []Answer `json:"authority,omitempty"`
+	Additional    []Answer `json:"additional,omitempty"`
+	Authoritative bool     `json:"authoritative"`
+	DurationMS    int64    `json:"duration_ms"`
+	Status        string   `json:"status"`
+	Error         string   `json:"error,omitempty"`
+}
+
+// TraceResult is the full delegation chain for a name/type pair.
+type TraceResult struct {
+	Name  string      `json:"name"`
+	Type  string      `json:"type"`
+	Steps []TraceStep `json:"steps"`
+}
+
 const (
 	StatusOK       = "ok"
 	StatusNXDomain = "nxdomain"

--- a/internal/dnsclient/result.go
+++ b/internal/dnsclient/result.go
@@ -66,4 +66,10 @@ type CheckSummary struct {
 	Errors           int            `json:"errors"`
 	UniqueAnswerSets int            `json:"unique_answer_sets"`
 	Consensus        map[string]int `json:"consensus"`
+	// ConvergedPct is the percentage of responding resolvers serving the majority answer.
+	ConvergedPct int `json:"converged_pct"`
+	// PropagationETA is the estimated seconds until full propagation, based on the maximum
+	// TTL observed across resolvers that diverge from the majority answer. Zero means
+	// already fully propagated; nil means not applicable (no majority / no responses).
+	PropagationETA *int64 `json:"propagation_eta,omitempty"`
 }

--- a/web/src/about.html
+++ b/web/src/about.html
@@ -27,6 +27,7 @@
           <a href="/" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Propagation</a>
           <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
           <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
+          <a href="/trace" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Trace</a>
           <a href="/api/docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
           <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -38,6 +38,7 @@
           <a href="/" class="nav-link-active px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Propagation</a>
           <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
           <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
+          <a href="/trace" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Trace</a>
           <a href="/api/docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
           <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>
@@ -63,6 +64,7 @@
         <a href="/" class="flex items-center px-3 py-2 rounded-lg text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Propagation Check</a>
         <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">DNS Lookup</a>
         <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Reverse DNS</a>
+        <a href="/trace" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Trace</a>
         <a href="/api/docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
         <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Settings</a>
       </div>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -141,6 +141,28 @@
                 <span x-text="shareLabel"></span>
               </button>
 
+              <!-- Snapshot controls -->
+              <button type="button" x-show="results.length > 0 && !snapshot" @click="saveSnapshot()"
+                class="btn bg-white/10 hover:bg-white/20 text-white ring-1 ring-white/20"
+                aria-label="Save snapshot for diff comparison">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                Snapshot
+              </button>
+              <template x-if="snapshot">
+                <div class="flex items-center gap-1">
+                  <span class="text-xs text-indigo-200">📸 <span x-text="snapshotTime"></span></span>
+                  <button type="button" @click="diffOnly = !diffOnly"
+                    class="btn text-xs ring-1 ring-white/20"
+                    :class="diffOnly ? 'bg-violet-500 text-white' : 'bg-white/10 hover:bg-white/20 text-white'"
+                    aria-label="Show only changed resolvers">
+                    Δ Changed
+                  </button>
+                  <button type="button" @click="clearSnapshot()"
+                    class="btn bg-white/10 hover:bg-white/20 text-white ring-1 ring-white/20 text-xs"
+                    aria-label="Clear snapshot">✕</button>
+                </div>
+              </template>
+
               <div x-show="results.length > 0" class="relative" x-data="{ exportOpen: false }">
                 <button type="button" @click="exportOpen = !exportOpen"
                   class="btn bg-white/10 hover:bg-white/20 text-white ring-1 ring-white/20"
@@ -358,7 +380,7 @@
                   <div class="text-xs font-mono text-emerald-700 dark:text-emerald-400 truncate" x-text="ans.value" :title="ans.value"></div>
                 </template>
               </div>
-              <!-- Location -->
+              <!-- Location + diff badge -->
               <div class="mt-1 ml-9 text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1.5">
                 <span class="relative group cursor-default leading-none">
                   <span class="fi rounded-sm ring-1 ring-black/5"
@@ -367,6 +389,9 @@
                     x-text="countryName(result.resolver.country)"></span>
                 </span>
                 <span x-text="result.resolver.city || ''"></span>
+                <template x-if="snapshot && snapshotDiff(result) === 'changed'">
+                  <span class="px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 font-medium">Δ changed</span>
+                </template>
               </div>
             </div>
           </template>
@@ -400,6 +425,7 @@
                   </th>
                 </template>
                 <th class="text-left px-4 py-3 font-medium w-16" scope="col">TTL</th>
+                <th x-show="snapshot" class="text-left px-4 py-3 font-medium w-10" scope="col">Δ</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-slate-100 dark:divide-slate-800/60">
@@ -458,6 +484,18 @@
                   <!-- TTL -->
                   <td class="px-4 py-3 text-slate-400 dark:text-slate-500 text-xs font-mono">
                     <span x-text="result.answers?.[0]?.ttl ? result.answers[0].ttl + 's' : '—'"></span>
+                  </td>
+                  <!-- Δ diff badge -->
+                  <td x-show="snapshot" class="px-4 py-3 text-xs font-medium">
+                    <template x-if="snapshotDiff(result) === 'changed'">
+                      <span class="px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400">changed</span>
+                    </template>
+                    <template x-if="snapshotDiff(result) === 'appeared'">
+                      <span class="px-1.5 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400">new</span>
+                    </template>
+                    <template x-if="snapshotDiff(result) === 'same'">
+                      <span class="text-slate-300 dark:text-slate-600">—</span>
+                    </template>
                   </td>
                 </tr>
               </template>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -225,6 +225,22 @@
             <span class="text-slate-500 dark:text-slate-400">Unique answers</span>
             <span class="font-semibold text-slate-900 dark:text-white" x-text="summary?.unique_answer_sets"></span>
           </div>
+          <!-- Convergence % -->
+          <div x-show="summary?.converged_pct != null" class="flex items-center gap-2">
+            <div class="w-2 h-2 rounded-full flex-shrink-0"
+              :class="summary?.converged_pct >= 100 ? 'bg-emerald-500' : 'bg-violet-500'"></div>
+            <span class="text-slate-500 dark:text-slate-400">Converged</span>
+            <span class="font-semibold"
+              :class="summary?.converged_pct >= 100 ? 'text-emerald-600 dark:text-emerald-400' : 'text-violet-600 dark:text-violet-400'"
+              x-text="summary?.converged_pct + '%'"></span>
+          </div>
+          <!-- Propagation ETA -->
+          <div x-show="summary?.propagation_eta != null && summary?.propagation_eta > 0" class="flex items-center gap-2">
+            <div class="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0"></div>
+            <span class="text-slate-500 dark:text-slate-400">Propagation ETA</span>
+            <span class="font-semibold text-amber-600 dark:text-amber-400"
+              x-text="formatETA(summary?.propagation_eta)"></span>
+          </div>
           <div x-show="summary?.nxdomain > 0" class="flex items-center gap-2">
             <div class="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0"></div>
             <span class="text-slate-500 dark:text-slate-400">NXDOMAIN</span>

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -36,6 +36,20 @@ function countryName(code) {
 }
 
 // ---------------------------------------------------------------------------
+// Propagation ETA helper: converts seconds to a human-readable string.
+// ---------------------------------------------------------------------------
+function formatETA(seconds) {
+  if (seconds == null || seconds <= 0) return '< 1s';
+  if (seconds < 60) return `~${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m < 60) return s > 0 ? `~${m}m ${s}s` : `~${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `~${h}h ${rm}m` : `~${h}h`;
+}
+
+// ---------------------------------------------------------------------------
 // dnsmonApp — DNS Propagation Checker (index.html)
 // ---------------------------------------------------------------------------
 function dnsmonApp() {
@@ -330,6 +344,7 @@ function dnsmonApp() {
     // Helpers exposed to templates
     // ---------------------------------------------------------------------------
     countryName,
+    formatETA,
 
     // ---------------------------------------------------------------------------
     // Internal helpers

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -78,6 +78,11 @@ function dnsmonApp() {
     page: 1,
     pageSize: 25,
 
+    // Snapshot (diff baseline)
+    snapshot: null,       // {[resolver_id]: canonicalKey}
+    snapshotTime: '',
+    diffOnly: false,      // filter table to changed resolvers only
+
     // Map
     _map: null,
     _markerLayer: null,
@@ -304,21 +309,22 @@ function dnsmonApp() {
     // ---------------------------------------------------------------------------
     get totalPages() {
       if (this.pageSize === 0) return 1;
-      return Math.max(1, Math.ceil(this.results.length / this.pageSize));
+      return Math.max(1, Math.ceil(this.diffFilteredResults.length / this.pageSize));
     },
 
     get pagedResults() {
-      if (this.pageSize === 0) return this.sortedResults;
+      if (this.pageSize === 0) return this.diffFilteredResults;
       const start = (this.page - 1) * this.pageSize;
-      return this.sortedResults.slice(start, start + this.pageSize);
+      return this.diffFilteredResults.slice(start, start + this.pageSize);
     },
 
     get pageRangeLabel() {
-      if (this.results.length === 0) return '';
-      if (this.pageSize === 0) return `1–${this.results.length} of ${this.results.length}`;
+      const total = this.diffFilteredResults.length;
+      if (total === 0) return '';
+      if (this.pageSize === 0) return `1–${total} of ${total}`;
       const start = (this.page - 1) * this.pageSize + 1;
-      const end = Math.min(this.page * this.pageSize, this.results.length);
-      return `${start}–${end} of ${this.results.length}`;
+      const end = Math.min(this.page * this.pageSize, total);
+      return `${start}–${end} of ${total}`;
     },
 
     get pageNumbers() {
@@ -360,6 +366,43 @@ function dnsmonApp() {
       if (this._markerLayer) {
         this._markerLayer.clearLayers();
       }
+    },
+
+    // ---------------------------------------------------------------------------
+    // Snapshot / diff
+    // ---------------------------------------------------------------------------
+    _answerKey(result) {
+      if (!result.answers || result.answers.length === 0) return result.status || '';
+      return result.answers.map((a) => a.value).sort().join(',');
+    },
+
+    saveSnapshot() {
+      const snap = {};
+      for (const r of this.results) snap[r.resolver.id] = this._answerKey(r);
+      this.snapshot = snap;
+      this.snapshotTime = new Date().toLocaleTimeString();
+      this.diffOnly = false;
+    },
+
+    clearSnapshot() {
+      this.snapshot = null;
+      this.snapshotTime = '';
+      this.diffOnly = false;
+    },
+
+    // Returns 'same' | 'changed' | 'appeared' | null (no snapshot).
+    snapshotDiff(result) {
+      if (!this.snapshot) return null;
+      const prev = this.snapshot[result.resolver.id];
+      const curr = this._answerKey(result);
+      if (prev === undefined) return 'appeared';
+      if (prev === curr) return 'same';
+      return 'changed';
+    },
+
+    get diffFilteredResults() {
+      if (!this.snapshot || !this.diffOnly) return this.sortedResults;
+      return this.sortedResults.filter((r) => this.snapshotDiff(r) !== 'same');
     },
   };
 }

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -1000,6 +1000,46 @@ function settingsApp() {
 }
 
 // ---------------------------------------------------------------------------
+// traceApp — Authoritative trace page (trace.html)
+// ---------------------------------------------------------------------------
+function traceApp() {
+  return {
+    domain: '',
+    type: 'A',
+    steps: [],
+    loading: false,
+    errorMsg: '',
+
+    async trace() {
+      if (!this.domain.trim()) return;
+      this.steps = [];
+      this.errorMsg = '';
+      this.loading = true;
+
+      try {
+        const resp = await fetch('/api/v1/trace', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: this.domain.trim(), type: this.type }),
+        });
+
+        if (!resp.ok) {
+          const err = await resp.json().catch(() => ({ error: { message: resp.statusText } }));
+          throw new Error(err?.error?.message || `HTTP ${resp.status}`);
+        }
+
+        const data = await resp.json();
+        this.steps = data.steps || [];
+      } catch (err) {
+        this.errorMsg = err.message;
+      } finally {
+        this.loading = false;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // loginApp — Sign-in page (login.html)
 // ---------------------------------------------------------------------------
 function loginApp() {
@@ -1040,6 +1080,7 @@ document.addEventListener('alpine:init', () => {
   Alpine.data('dnsmonApp', dnsmonApp);
   Alpine.data('lookupApp', lookupApp);
   Alpine.data('reverseApp', reverseApp);
+  Alpine.data('traceApp', traceApp);
   Alpine.data('settingsApp', settingsApp);
   Alpine.data('loginApp', loginApp);
 });

--- a/web/src/lookup.html
+++ b/web/src/lookup.html
@@ -27,6 +27,7 @@
           <a href="/" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Propagation</a>
           <a href="/lookup" class="nav-link-active px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">DNS Lookup</a>
           <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
+          <a href="/trace" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Trace</a>
           <a href="/api/docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
           <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
         </div>
@@ -48,6 +49,7 @@
         <a href="/" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Propagation Check</a>
         <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">DNS Lookup</a>
         <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Reverse DNS</a>
+        <a href="/trace" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Trace</a>
         <a href="/api/docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
         <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Settings</a>
       </div>

--- a/web/src/trace.html
+++ b/web/src/trace.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dnsmon — Authoritative Trace</title>
+  <meta name="description" content="Walk the DNS delegation chain from root to the authoritative nameserver, equivalent to dig +trace." />
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body class="min-h-screen" x-data>
+
+  <!-- Navigation -->
+  <nav class="sticky top-0 z-50 bg-white/90 dark:bg-slate-950/90 backdrop-blur border-b border-slate-200/80 dark:border-slate-800/80">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between h-14">
+
+        <!-- Logo -->
+        <a href="/" class="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-bold text-lg" aria-label="dnsmon home">
+          <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+          </svg>
+          <span>dnsmon</span>
+        </a>
+
+        <!-- Desktop links -->
+        <div class="hidden md:flex items-center gap-1">
+          <a href="/" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Propagation</a>
+          <a href="/lookup" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">DNS Lookup</a>
+          <a href="/reverse" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Reverse DNS</a>
+          <a href="/trace" class="nav-link-active px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Trace</a>
+          <a href="/api/docs" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">API</a>
+          <a href="/settings" class="nav-link px-3 py-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800/60">Settings</a>
+        </div>
+
+        <!-- Right: dark mode + mobile menu -->
+        <div class="flex items-center gap-1">
+          <button onclick="toggleDark()" class="p-2 rounded-lg text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors" aria-label="Toggle dark mode">
+            <svg class="w-4 h-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            <svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+          </button>
+          <button class="md:hidden p-2 rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors" aria-label="Toggle menu" @click="$refs.mobileNav.classList.toggle('hidden')">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Mobile nav -->
+      <div x-ref="mobileNav" class="hidden md:hidden py-2 space-y-0.5">
+        <a href="/" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Propagation Check</a>
+        <a href="/lookup" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">DNS Lookup</a>
+        <a href="/reverse" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Reverse DNS</a>
+        <a href="/trace" class="flex items-center px-3 py-2 rounded-lg text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/40" aria-current="page">Trace</a>
+        <a href="/api/docs" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">API Docs</a>
+        <a href="/settings" class="flex items-center px-3 py-2 rounded-lg text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800">Settings</a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Main -->
+  <main x-data="traceApp()">
+
+    <!-- Hero -->
+    <div class="bg-gradient-to-br from-indigo-600 via-indigo-700 to-violet-800 dark:from-indigo-950 dark:via-slate-950 dark:to-violet-950">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-14">
+        <div class="mb-6">
+          <h1 class="text-2xl sm:text-3xl font-bold text-white mb-1.5">Authoritative Trace</h1>
+          <p class="text-indigo-200 dark:text-indigo-300 text-sm sm:text-base">
+            Walk the full DNS delegation chain from root nameservers down to the authoritative server — equivalent to <code class="bg-white/20 px-1.5 py-0.5 rounded text-white font-mono text-xs">dig +trace</code>.
+          </p>
+        </div>
+
+        <!-- Form -->
+        <div class="bg-white/10 dark:bg-white/5 backdrop-blur-sm ring-1 ring-white/20 rounded-2xl p-4 sm:p-5">
+          <form @submit.prevent="trace()" class="space-y-3">
+            <div class="flex flex-col sm:flex-row gap-2.5">
+              <div class="flex-1">
+                <label for="trace-domain" class="block text-xs font-medium text-indigo-200 mb-1">Domain Name</label>
+                <input id="trace-domain" type="text" x-model="domain" placeholder="example.com"
+                  autocomplete="off" autocapitalize="none" spellcheck="false"
+                  class="input bg-white/10 dark:bg-white/5 ring-white/20 text-white placeholder:text-indigo-300 focus:ring-white/50 focus:bg-white/15"
+                  aria-required="true" />
+              </div>
+              <div class="sm:w-32">
+                <label for="trace-type" class="block text-xs font-medium text-indigo-200 mb-1">Record Type</label>
+                <select id="trace-type" x-model="type" class="input bg-white/10 dark:bg-white/5 ring-white/20 text-white focus:ring-white/50">
+                  <option class="bg-slate-800 text-white">A</option>
+                  <option class="bg-slate-800 text-white">AAAA</option>
+                  <option class="bg-slate-800 text-white">CNAME</option>
+                  <option class="bg-slate-800 text-white">MX</option>
+                  <option class="bg-slate-800 text-white">NS</option>
+                  <option class="bg-slate-800 text-white">TXT</option>
+                  <option class="bg-slate-800 text-white">SOA</option>
+                </select>
+              </div>
+            </div>
+            <div>
+              <button type="submit"
+                class="btn bg-white hover:bg-indigo-50 text-indigo-700 font-semibold shadow-md"
+                :disabled="loading" aria-label="Run authoritative trace">
+                <svg class="w-4 h-4" :class="{ 'animate-spin': loading }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                <span x-text="loading ? 'Tracing…' : 'Trace'"></span>
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <!-- Error -->
+        <div x-show="errorMsg" class="mt-3 flex items-start gap-3 bg-rose-500/20 ring-1 ring-rose-400/30 rounded-xl p-4 text-rose-100 text-sm" role="alert" aria-live="assertive">
+          <svg class="w-4 h-4 mt-0.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+          <span x-text="errorMsg"></span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+      <!-- Delegation chain -->
+      <div x-show="steps.length > 0">
+        <h2 class="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-4">
+          Delegation chain — <span x-text="steps.length"></span> hop<span x-show="steps.length !== 1">s</span>
+        </h2>
+
+        <ol class="relative border-l-2 border-indigo-200 dark:border-indigo-900 space-y-0 ml-3">
+          <template x-for="(step, i) in steps" :key="i">
+            <li class="mb-6 ml-6">
+              <!-- Timeline dot -->
+              <span class="absolute -left-2.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-white dark:ring-slate-950"
+                :class="step.authoritative ? 'bg-emerald-500' : (step.status === 'ok' ? 'bg-indigo-500' : 'bg-rose-500')">
+                <svg class="w-3 h-3 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true">
+                  <template x-if="step.authoritative"><path d="M20 6L9 17l-5-5"/></template>
+                  <template x-if="!step.authoritative && step.status === 'ok'"><path d="M5 12h14M12 5l7 7-7 7"/></template>
+                  <template x-if="step.status !== 'ok' && !step.authoritative"><path d="M18 6L6 18M6 6l12 12"/></template>
+                </svg>
+              </span>
+
+              <!-- Step card -->
+              <div class="card p-4 ml-0">
+                <!-- Header row -->
+                <div class="flex flex-wrap items-start justify-between gap-2 mb-3">
+                  <div>
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <span class="font-mono text-sm font-semibold text-slate-900 dark:text-white" x-text="step.zone || '.'"></span>
+                      <span x-show="step.authoritative"
+                        class="text-xs px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400 font-medium">
+                        Authoritative
+                      </span>
+                      <span x-show="!step.authoritative && step.status === 'ok'"
+                        class="text-xs px-1.5 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 font-medium">
+                        Referral
+                      </span>
+                      <span x-show="step.status !== 'ok'"
+                        class="text-xs px-1.5 py-0.5 rounded bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-400 font-medium"
+                        x-text="step.status.toUpperCase()">
+                      </span>
+                    </div>
+                    <div class="text-xs text-slate-500 dark:text-slate-400 mt-0.5 font-mono">
+                      <span x-text="step.nameserver"></span>
+                      <span class="text-slate-300 dark:text-slate-600"> @ </span>
+                      <span x-text="step.ip"></span>
+                    </div>
+                  </div>
+                  <span class="text-xs font-mono text-slate-400 dark:text-slate-500 flex-shrink-0"
+                    x-text="step.duration_ms + 'ms'"></span>
+                </div>
+
+                <!-- Error -->
+                <div x-show="step.error" class="text-xs font-mono text-rose-600 dark:text-rose-400 mb-2" x-text="step.error"></div>
+
+                <!-- Answer section -->
+                <div x-show="step.answers && step.answers.length > 0" class="mb-2">
+                  <div class="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide mb-1">Answer</div>
+                  <div class="bg-slate-50 dark:bg-slate-800/60 rounded-lg p-2 space-y-1">
+                    <template x-for="(ans, j) in step.answers" :key="j">
+                      <div class="flex items-baseline gap-3 text-xs font-mono">
+                        <span class="text-slate-400 dark:text-slate-500 flex-shrink-0 w-20 truncate" x-text="ans.name"></span>
+                        <span class="text-indigo-500 dark:text-indigo-400 flex-shrink-0 w-12" x-text="ans.type"></span>
+                        <span class="text-slate-400 dark:text-slate-500 flex-shrink-0 w-16" x-text="ans.ttl + 's'"></span>
+                        <span class="text-emerald-700 dark:text-emerald-400 break-all" x-text="ans.value"></span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+
+                <!-- Authority section -->
+                <div x-show="step.authority && step.authority.length > 0">
+                  <div class="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide mb-1">Authority</div>
+                  <div class="bg-slate-50 dark:bg-slate-800/60 rounded-lg p-2 space-y-1">
+                    <template x-for="(rr, j) in step.authority" :key="j">
+                      <div class="flex items-baseline gap-3 text-xs font-mono">
+                        <span class="text-slate-400 dark:text-slate-500 flex-shrink-0 w-20 truncate" x-text="rr.name"></span>
+                        <span class="text-indigo-500 dark:text-indigo-400 flex-shrink-0 w-12" x-text="rr.type"></span>
+                        <span class="text-slate-400 dark:text-slate-500 flex-shrink-0 w-16" x-text="rr.ttl + 's'"></span>
+                        <span class="text-slate-700 dark:text-slate-300 break-all" x-text="rr.value"></span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </template>
+        </ol>
+      </div>
+
+      <!-- Empty state -->
+      <div x-show="!loading && steps.length === 0 && !errorMsg" class="py-20 text-center">
+        <div class="w-16 h-16 mx-auto mb-4 rounded-2xl bg-indigo-100 dark:bg-indigo-950/60 flex items-center justify-center">
+          <svg class="w-8 h-8 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path d="M5 12h14M12 5l7 7-7 7"/>
+          </svg>
+        </div>
+        <h2 class="text-slate-700 dark:text-slate-300 font-semibold text-lg">Enter a domain to trace</h2>
+        <p class="text-slate-400 dark:text-slate-500 text-sm mt-1 max-w-sm mx-auto">
+          Shows the full delegation path from root nameservers down to the authoritative server for the domain.
+        </p>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="border-t border-slate-200 dark:border-slate-800 mt-12 py-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400 dark:text-slate-500">
+        <div class="flex items-center gap-2">
+          <svg class="w-5 h-5 text-indigo-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          <span class="font-medium text-slate-600 dark:text-slate-300">dnsmon</span>
+          <span>&#8212; Self-hosted DNS propagation checker</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <a href="/about" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">About</a>
+          <a href="https://github.com/t0mer/dnsmon" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="/api/docs" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">API</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script defer src="/js/app.js"></script>
+  <script defer src="/vendor/alpine.js"></script>
+</body>
+</html>


### PR DESCRIPTION
  - Propagation ETA — CheckSummary now includes converged_pct (% of resolvers serving the majority answer) and propagation_eta (estimated seconds until full propagation,
  computed as the max TTL across resolvers still returning a divergent answer). The summary stats bar shows both with colour coding: violet while propagating, emerald when 100%
   converged, and a human-readable countdown (e.g. ~2m 30s).
  - Snapshot diff — A "Snapshot" button appears after any check completes. On the next check, a Δ column labels each resolver as changed, new, or — (unchanged) relative to the
  saved baseline. A "Δ Changed" toggle filters the table to only divergent resolvers. Pure frontend — no API or storage changes required.
  - Authoritative trace (dig +trace equivalent) — New POST /api/v1/trace endpoint and /trace page. Sends non-recursive queries (RD=0) starting from IANA root servers, follows
  NS referrals hop by hop down to the authoritative nameserver. Prefers IPv4 glue; falls back to system resolver (IPv4-first) when no glue is present in the additional section.
   Each hop in the UI shows the zone, nameserver, IP, status badge (Referral / Authoritative / error), answer records, and round-trip time.

  Test Plan

  - [x] go build ./... — clean
  - [x] go test ./... — all packages pass
  - [x] Live trace of github.com A returns 3 hops (root → .com TLD → authoritative) with AA=true on final step
  - [x] propagation_eta = 0 when all resolvers agree; > 0 when divergent (verified via API response)
  - [ ] Snapshot diff: run a check, save snapshot, run again — verify Δ column appears and "Changed only" filter works
  - [ ] Trace page: open /trace, enter a domain, verify delegation steps render correctly in the timeline UI
  - [ ] Verify new nav "Trace" link appears on all pages